### PR TITLE
MHV support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,19 @@ You can also grab the development certificates from [here](https://github.com/de
 
 ## SAML Flow
 
+The proxy fills both roles typically seen in a SAML interaction:
+- It acts as an Identity Provider (IDP) relative to Okta. It receives a SAML request from Okta, and returns a SAML response.
+- It acts as a Service Provider (SP) relative to ID.me. It sends a SAML request to ID.me, and receives a SAML response. 
+
+These two interactions are interleaved, - the request received from Okta is re-signed and passed along to ID.me. Then the respone from ID.me is validated, transformed, re-signed, and passed along to Okta. 
+
 Flow of the SAML login process: 
 
 ```
 +-----------------------+
 |                       |
 |  User clicks          |
-|  "Login with Va.go^"  |
+|  "Login with Va.gov"  |
 |                       |
 +---|-------------------+
     |
@@ -81,8 +87,8 @@ Flow of the SAML login process:
     |
 +---v---------------+     +-------------------------------+     +-------------------------+
 |                   |     |                               |     |                         |
-|  GET /authorize   |     |  POST /sso                    |     |  User is presented      |
-|  Okta starts SAML +----->  Proxy recei^es AuthNRequest  +-----+  with DSLogon, Id.me, & |
+|  GET /authorize   |     |  POST /samlproxy/idp/saml/sso |     |  User is presented      |
+|  Okta starts SAML +----->  Proxy receives AuthNRequest  +-----+  with DSLogon, Id.me, & |
 |  IdP flow         |     |  From Okta                    |     |  MHV login options      |
 |                   |     |                               |     |                         |
 +-------------------+     +-------------------------------+     +----|-----|---|----------+
@@ -113,7 +119,7 @@ Flow of the SAML login process:
    |    |    |
    |    |    |       +-------------------------------+    +---------------------------+
  +-v----v----v--+    |                               |    |                           |
- |              |    | GET /sso                      |    |  Proxy POSTS SAMLResponse |
+ |              |    | GET /samlproxy/sp/saml/sso    |    |  Proxy POSTS SAMLResponse |
  | User logs in +----> Proxy receives redirect from  +---->  To Okta                  |
  |              |    | Id.me with SAMLResponse       |    |                           |
  +--------------+    |                               |    +---------------------------+

--- a/config.js
+++ b/config.js
@@ -163,7 +163,7 @@ var metadata = [
     if (claims && claims.mhv_profile) {
       return JSON.parse(claims.mhv_profile).accountType;
     }
-    return null;
+    return undefined;
   }
 }
 ];

--- a/config.js
+++ b/config.js
@@ -1,7 +1,9 @@
 /**
  * SAML Attribute Metadata
  */
-var metadata = [{
+var metadata = [
+// Common attributes
+{
   id: "email",
   optional: false,
   displayName: 'E-Mail Address',
@@ -25,7 +27,9 @@ var metadata = [{
   displayName: 'uuid',
   description: 'IdP-generated UUID of the user',
   multiValue: false
-}, {
+},
+// ID.me-specific attributes
+{
   id: "fname",
   optional: true,
   displayName: 'First Name',
@@ -55,7 +59,9 @@ var metadata = [{
   displayName: 'Gender',
   description: 'The administrative gender of the user',
   multiValue: false
-}, {
+},
+// DSLogon-specific attributes
+{
   id: "birth_date",
   optional: true,
   displayName: 'Birth Date',
@@ -127,7 +133,40 @@ var metadata = [{
   displayName: 'DS Logon UUID',
   description: 'DSLogon-reported UUID aka EDIPI',
   multiValue: false
-}];
+},
+// MHV-specific attributes
+{
+  id: "mhv_uuid",
+  optional: true,
+  displayName: 'MHV UUID',
+  description: 'MHV-reported UUID',
+  multiValue: false
+}, {
+  id: "mhv_profile",
+  optional: true,
+  displayName: 'MHV user profile',
+  description: 'MHV user profile, includes account status',
+  multiValue: false
+}, {
+  id: "mhv_icn",
+  optional: true,
+  displayName: 'MHV ICN',
+  description: 'MHV-reported ICN',
+  multiValue: false
+}, {
+  id: "mhv_account_type",
+  optional: true,
+  displayName: 'MHV account type',
+  description: 'MHV account type',
+  multiValue: false,
+  transformer: function (claims) {
+    if (claims && claims.mhv_profile) {
+      return JSON.parse(claims.mhv_profile).accountType;
+    }
+    return null;
+  }
+}
+];
 
 module.exports = {
   metadata: metadata

--- a/src/SPConfig.js
+++ b/src/SPConfig.js
@@ -1,5 +1,5 @@
 import { SP_ERROR_URL, SP_SLO_URL } from "./routes/constants";
-import { removeHeaders, getReqURl } from "./utils";
+import { removeHeaders, getReqUrl } from "./utils";
 
 import fs from "fs";
 import process from "process";

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -188,6 +188,7 @@ export const acsFactory = (app, acsUrl) => {
     function(req, res, next) {
       const authOptions = assignIn({}, req.idp.options);
       authOptions.RelayState = req.session.ssoResponse.state;
+      authOptions.authnContextClassRef = req.user.authnContext.authnMethod;
       samlp.auth(authOptions)(req, res);
     }
   );

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -142,7 +142,7 @@ export const idpSignIn = function(req, res) {
 
 export const sufficientLevelOfAssurance = (claims) => {
   if (claims.mhv_profile) {
-    profile = JSON.parse(claims.mhv_profile);
+    var profile = JSON.parse(claims.mhv_profile);
     return (profile.accountType == 'Premium');
   }
   else if (claims.dslogon_assurance) {

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -149,7 +149,7 @@ export const sufficientLevelOfAssurance = (claims) => {
     return claims.dslogon_assurance == '2';
   }
   else {
-    return claims.level_of_assurnace == '3';
+    return claims.level_of_assurance == '3';
   }
 };
 

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -140,6 +140,19 @@ export const idpSignIn = function(req, res) {
   samlp.auth(authOptions)(req, res);
 };
 
+export const sufficientLevelOfAssurance = (claims) => {
+  if (claims.mhv_profile) {
+    profile = JSON.parse(claims.mhv_profile);
+    return (profile.accountType == 'Premium');
+  }
+  else if (claims.dslogon_assurance) {
+    return claims.dslogon_assurance == '2';
+  }
+  else {
+    return claims.level_of_assurnace == '3';
+  }
+};
+
 export const acsFactory = (app, acsUrl) => {
   app.get(
     getPath(acsUrl),
@@ -162,8 +175,7 @@ export const acsFactory = (app, acsUrl) => {
     function(req, res, next) {
       console.log(req.user);
       if (req.user && req.user.claims &&
-          (req.user.claims.level_of_assurance !== '3' &&
-           req.user.claims.dslogon_assurance !== '2')) {
+          !sufficientLevelOfAssurance(req.user.claims)) {
         res.redirect(url.format({
           pathname: IDP_SSO,
           query: {

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -146,7 +146,7 @@ export const sufficientLevelOfAssurance = (claims) => {
     return (profile.accountType == 'Premium');
   }
   else if (claims.dslogon_assurance) {
-    return claims.dslogon_assurance == '2';
+    return (claims.dslogon_assurance == '2' || claims.dslogon_assurance == '3');
   }
   else {
     return claims.level_of_assurance == '3';

--- a/src/simpleProfileMapper.js
+++ b/src/simpleProfileMapper.js
@@ -10,9 +10,14 @@ SimpleProfileMapper.prototype.getClaims = function() {
   var claims = {};
 
   SimpleProfileMapper.prototype.metadata.forEach(function(entry) {
-    claims[entry.id] = entry.multiValue ?
-      self._pu['claims'][entry.id].split(',') :
-      self._pu['claims'][entry.id];
+    if (entry.transformer) {
+      claims[entry.id] = entry.transformer(self._pu['claims']);
+    }
+    else {
+      claims[entry.id] = entry.multiValue ?
+        self._pu['claims'][entry.id].split(',') :
+        self._pu['claims'][entry.id];
+    }
   });
 
   console.log(claims);


### PR DESCRIPTION
- Adds profile mapping to support MHV.
- Adds a profile mapping option that supports a transformation method, used to map MHV's complex profile object onto a single account_type string.
- Updates allowed LOAs for DSLogon
- Preserves ID.me-provided authnContext in response path through to Okta. 