### PR TITLE
Fix dockerfile healthcheck path

### DIFF
--- a/oauth-proxy/Dockerfile
+++ b/oauth-proxy/Dockerfile
@@ -13,6 +13,6 @@ ADD ./ .
 
 EXPOSE 7100 7100
 HEALTHCHECK --interval=1m --timeout=4s \
-  CMD curl -f http://localhost:7100/.well-known/smart-configuration.json || exit 1
+  CMD curl -f http://localhost:7100/oauth2/.well-known/openid-configuration || exit 1
 
 ENTRYPOINT ["node", "index.js"]


### PR DESCRIPTION
Fixed path to health check.

Due to https://github.com/department-of-veterans-affairs/vets-contrib/issues/758, this won't actually make the container show as healthy, but might as well fix this part so it's correct for the eventual health check.