### PR TITLE
Make aws key config optional

### DIFF
--- a/oauth-proxy/cli.js
+++ b/oauth-proxy/cli.js
@@ -20,13 +20,13 @@ function processArgs() {
       },
       aws_secret: {
         description: "AWS Secret Access Key",
-        required: true,
-        default: 'NONE',
+        required: false,
+        default: null,
       },
       aws_id: {
         description: "AWS Access ID",
-        required: true,
-        default: 'NONE',
+        required: false,
+        default: null,
       },
       aws_region: {
         description: "AWS Region",

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -71,11 +71,11 @@ const smartCapabilities = [
 ]
 
 const dynamo = dynamoClient.createClient(
-  {
-    accessKeyId: config.aws_id,
-    region: config.aws_region,
-    secretAccessKey: config.aws_secret,
-  },
+  Object.assign({},
+    { region: config.aws_region },
+    config.aws_id === null ? null : { accessKeyId: config.aws_id },
+    config.aws_secret === null ? null : { secretAccessKey: config.aws_secret }
+  ),
   config.dynamo_local,
   config.dynamo_table_name,
 );


### PR DESCRIPTION
Don't set default values for access key/id, to allow aws-sdk to read them from instance metadata.