### PR TITLE
Set HTTP keepalive timeouts greater than ELB idle timeouts

### DIFF
--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -274,7 +274,8 @@ function startApp(issuer) {
   });
 
   app.use(well_known_base_path, router)
-  app.listen(port, () => console.log(`OAuth Proxy listening on port ${port}!`));
+  server = app.listen(port, () => console.log(`OAuth Proxy listening on port ${port}!`));
+  server.keepAliveTimeout = 75000;
   return app;
 }
 

--- a/saml-proxy/src/app.js
+++ b/saml-proxy/src/app.js
@@ -67,6 +67,7 @@ function runServer(argv) {
 
       console.log('starting proxy server on port %s', app.get('port'));
 
+      httpServer.keepAliveTimeout = 75000;
       httpServer.listen(app.get('port'), function() {
         const scheme   = argv.idpHttps ? 'https' : 'http',
               address  = httpServer.address(),


### PR DESCRIPTION
Per guidance here: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-idle-timeout.html

Default was 5 seconds, going to set ELB idle timeout to 60 seconds. 