### PR TITLE
Fix IDMeProfileMapper upstream ID provider detection.

### DIFF
--- a/saml-proxy/docs/example-idme-profile-received-by-passport.json
+++ b/saml-proxy/docs/example-idme-profile-received-by-passport.json
@@ -1,0 +1,22 @@
+{
+   "http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod" : "http://idmanagement.gov/ns/assurance/loa/3",
+   "uuid" : "88f572d491af46efa393cba6c351e252",
+   "social" : "796126859",
+   "level_of_assurance" : "3",
+   "gender" : "male",
+   "mname" : "J",
+   "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier" : "88f572d491af46efa393cba6c351e252",
+   "birth_date" : "1932-02-05",
+   "issuer" : "api.idmelabs.com",
+   "sessionIndex" : "_d1e7cbdda39943eda2529b86d95cffd1",
+   "multifactor" : "true",
+   "fname" : "HECTOR",
+   "nameIdAttributes" : {
+      "NameQualifier" : "api.idmelabs.com",
+      "value" : "88f572d491af46efa393cba6c351e252",
+      "Format" : "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+      "SPNameQualifier" : "samlproxy.vagov.dev"
+   },
+   "email" : "vets.gov.user+0@gmail.com",
+   "lname" : "ALLEN"
+}

--- a/saml-proxy/src/IDMeProfileMapper.test.ts
+++ b/saml-proxy/src/IDMeProfileMapper.test.ts
@@ -5,10 +5,6 @@ const idmeAssertions = {
   issuer: 'api.idmelabs.com',
   userName: 'ae9ff5f4e4b741389904087d94cd19b2',
   nameIdFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
-  authnContext: {
-    sessionIndex: '_dda86128dbf14a9b8643daadab889d54',
-    authnMethod: 'http://idmanagement.gov/ns/assurance/loa/3'
-  },
   claims: {
     birth_date: '1998-01-23',
     email: 'vets.gov.user+20@gmail.com',
@@ -27,10 +23,6 @@ const mhvAssertions = {
   issuer: 'api.idmelabs.com',
   userName: 'ae9ff5f4e4b741389904087d94cd19b2',
   nameIdFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
-  authnContext: {
-    sessionIndex: '_dda86128dbf14a9b8643daadab889d54',
-    authnMethod: 'myhealthevet'
-  },
   claims: {
     email: 'vets.gov.user+20@gmail.com',
     mhv_icn: 'anICN',
@@ -46,10 +38,6 @@ const dslogonAssertions = {
   issuer: 'api.idmelabs.com',
   userName: 'ae9ff5f4e4b741389904087d94cd19b2',
   nameIdFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
-  authnContext: {
-    sessionIndex: '_dda86128dbf14a9b8643daadab889d54',
-    authnMethod: 'dslogon'
-  },
   claims: {
     dslogon_birth_date: '1998-01-23',
     email: 'vets.gov.user+20@gmail.com',

--- a/saml-proxy/src/IDMeProfileMapper.ts
+++ b/saml-proxy/src/IDMeProfileMapper.ts
@@ -10,10 +10,6 @@ interface IClaimField {
 interface IClaimDescriptions { [key: string]: IClaimField };
 
 interface ISamlAssertions {
-  authnContext: {
-    sessionIndex: string;
-    authnMethod: string;
-  };
   claims: any
   userName: string,
   nameIdFormat: string;
@@ -225,9 +221,9 @@ export class IDMeProfileMapper implements ISamlpProfileMapper {
   public getMappedClaims(): object {
     let claims = {};
     this.getClaimFields(commonConfiguration, claims);
-    if (this.samlAssertions.authnContext.authnMethod === 'myhealthevet') {
+    if (this.samlAssertions.claims.mhv_uuid) {
       this.getClaimFields(mhvConfiguration, claims);
-    } else if (this.samlAssertions.authnContext.authnMethod === 'dslogon') {
+    } else if (this.samlAssertions.claims.dslogon_uuid) {
       this.getClaimFields(dsLogonConfiguration, claims);
     } else {
       this.getClaimFields(idmeConfiguration, claims);

--- a/saml-proxy/src/VetsAPIClient.test.ts
+++ b/saml-proxy/src/VetsAPIClient.test.ts
@@ -84,8 +84,6 @@ describe('getMVITraitsForLoa3User', () => {
         'x-va-idp-uuid': expect.any(String),
         'x-va-user-email': expect.any(String),
         'x-va-mhv-icn': expect.any(String),
-        'x-va-ssn': null,
-        'x-va-dslogon-edipi': null,
         'x-va-level-of-assurance': '3',
       }),
     });
@@ -107,8 +105,6 @@ describe('getMVITraitsForLoa3User', () => {
         'x-va-last-name': expect.any(String),
         'x-va-dob': expect.any(String),
         'x-va-gender': expect.any(String),
-        'x-va-mhv-icn': null,
-        'x-va-dslogon-edipi': null,
         'x-va-level-of-assurance': '3',
       }),
     });

--- a/saml-proxy/src/VetsAPIClient.ts
+++ b/saml-proxy/src/VetsAPIClient.ts
@@ -39,6 +39,8 @@ export class VetsAPIClient {
       'x-va-gender': user.gender || null,
       'x-va-level-of-assurance': '3',
     };
+    // @ts-ignore TS7017
+    Object.keys(headers).forEach((key) => (headers[key] == null) && delete headers[key]);
     const response = await request.get({
       url: `${this.apiHost}${LOOKUP_PATH}`,
       json: true,


### PR DESCRIPTION
As best I can tell, this class pulls double duty and the changes to the test suite adding the `authnContext` attribute were in error. The confusion stems from [this code](https://github.com/department-of-veterans-affairs/vets-saml-proxy/blob/dv-968-fix-upstream-provider-selection/saml-proxy/src/routes/passport.js#L11-L27):

```
      return done(null, {
        issuer: profile.issuer,
        userName: profile.nameIdAttributes.value,
        nameIdFormat: profile.nameIdAttributes.Format,
        authnContext: {
          sessionIndex: profile.sessionIndex,
          authnMethod: profile['http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod']
        },
        claims: new IDMeProfileMapper({claims: omit(
          profile,
          'issuer',
          'sessionIndex',
          'nameIdAttributes',
          'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier',
          'http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod'
        )}).getMappedClaims()
});
```

Because we have configured passport (or some passport plugin) [to use this class](https://github.com/department-of-veterans-affairs/vets-saml-proxy/blob/dv-968-fix-upstream-provider-selection/saml-proxy/src/IDPConfig.ts#L71) as the profile mapper, the object passed to the `done` callback in the code snippet above is passed into this class later in the request's lifecycle. That is done in order to call `getNameIdentifier`.

However, in the code snippet above we are also using it to reduce the set of profile fields under the `claims` key. The code was assuming that `authnContext` was always passed into it when in fact it's only there in the synthetic profile constructed here. That key is not present in the profile I was able to capture coming back from ID.me (translated by passport from the SAML XML attributes to the object documented in the sample JSON in this PR).

I strongly suspect we can split this class into two in the future but I don't have time to execute such a large refactor now. I need to either revert merge commit db01a6d9761c4bd6e99f07565b2a09fa4f4512e3 or merge this fix before the automatic deploy tomorrow at noon eastern.

I've used the attribute-sniffing approach in `getMappedClaims` because I have example XML SAML assertions showing those fields. It looks like we could examine the attribute with the key `http://schemas.microsoft.com/ws/2008/06/identity/claims/authenticationmethod`. That is present in the profile object I captured. However that appears to be injected by passport and not endemic to the ID.me SAML assertions. Since I wasn't able to interactively test a DSLogon or MHV login and capture the resulting passport profile object, I felt less confident in that approach for this PR.