### PR TITLE
Use mapped field name for MHV user detection.

### DIFF
--- a/saml-proxy/src/routes/acsHandlers.ts
+++ b/saml-proxy/src/routes/acsHandlers.ts
@@ -17,9 +17,11 @@ const mviErrorTemplate = (error: any) => {
   }
 };
 
+// This depends on being called after buildPassportLoginHandler because it uses
+// the mapped claim mhv_account_type.
 const sufficientLevelOfAssurance = (claims: any) => {
   if (claims.mhv_account_type) {
-    return (claims.accountType === 'Premium');
+    return (claims.mhv_account_type === 'Premium');
   }
   else if (claims.dslogon_assurance) {
     return (claims.dslogon_assurance === '2' || claims.dslogon_assurance === '3');


### PR DESCRIPTION
This fixes an oversight made in the profile mapper refactor. Need to test in dev because MHV test users are restricted to VA network.