### PR TITLE
Remove MHV/health qualifiers from error message

### DIFF
--- a/saml-proxy/views/icnLookupFailure.hbs
+++ b/saml-proxy/views/icnLookupFailure.hbs
@@ -1,8 +1,8 @@
-<h2>MyHealtheVet Tools Not Working</h2>
+<h2>VA Tools Not Working</h2>
 
 {{#>deptva-formation-error}}
   <h3 class="usa-alert-heading">
-    Some VA.gov health tools aren't working right now
+    Some VA.gov tools aren't working right now
   </h3>
 
   <p>


### PR DESCRIPTION
This error screen is generic to all OAuth interactions, not just health ones. And there's no connection whatsoever to Myhealthevet. I think that was incorrect carry over from some suggested VA.gov error messages.