### PR TITLE
OAuth proxy runnable via docker compose

### DIFF
--- a/oauth-proxy/docker-compose.yml
+++ b/oauth-proxy/docker-compose.yml
@@ -17,6 +17,11 @@ services:
       - dynamodb
     ports:
       - "7100:7100"
+    environment:
+      # The values here must match the values found in dynamo_schema.js.
+      - AWS_ACCESS_KEY_ID=NONE
+      - AWS_SECRET_ACCESS_KEY=NONE
+      - AWS_DEFAULT_REGION=us-west-2
     volumes:
       - .:/opt/app
     command: "--config dev-config.json"

--- a/oauth-proxy/dynamo_schema.js
+++ b/oauth-proxy/dynamo_schema.js
@@ -1,5 +1,6 @@
 const { config, DynamoDB } = require('aws-sdk');
 
+// The credenials set here must match those found in docker-compose.yml, oauth-proxy
 config.update({
   accessKeyId: 'NONE',
   region: 'us-west-2',


### PR DESCRIPTION
Add AWS credential environment variables to docker-compose that match those in dynamo_schema.js. This helps the proxy and schema script talk to the same local dynamoDB table.