### PR TITLE
Ensure docker stage is run on jenkins swarm node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,7 @@ pipeline {
         dockerfile {
           args "--entrypoint='' -u 0:0"
           dir "saml-proxy"
+          label 'vetsgov-general-purpose'
         }
       }
 


### PR DESCRIPTION
This second `agent` directive was causing our builds to sometimes change over to the Jenkins master node, which doesn't have docker installed.

Context:
https://lighthouseva.slack.com/archives/CE79R5SR1/p1554141205032100
https://dsva.slack.com/archives/C7S6EA0ES/p1554142651056000