### PR TITLE
Look up MVI users with OpenidAuth::V0::MviUsersController POST action…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ $RECYCLE.BIN/
 build/
 /test-report.xml
 /saml-proxy/public/core.css
+
+# Local config
+/saml-proxy/dev-config.json

--- a/saml-proxy/src/VetsAPIClient.test.ts
+++ b/saml-proxy/src/VetsAPIClient.test.ts
@@ -3,7 +3,7 @@ import * as request from 'request-promise-native';
 import { VetsAPIClient } from './VetsAPIClient';
 jest.mock('request-promise-native', () => {
   return {
-    get: jest.fn((_) => Promise.resolve({})),
+    post: jest.fn((_) => Promise.resolve({})),
   };
 });
 
@@ -37,8 +37,8 @@ const samlTraitsICN = {
 };
 
 beforeEach(() => {
-  request.get.mockReset();
-  request.get.mockImplementation((_) => Promise.resolve({
+  request.post.mockReset();
+  request.post.mockImplementation((_) => Promise.resolve({
     data: {
       id: 'fakeICN',
       type: "user-mvi-icn",
@@ -52,60 +52,66 @@ beforeEach(() => {
 });
 
 describe('getMVITraitsForLoa3User', () => {
-  it('should call the mvi-user endpoint with the Veteran\'s EIDPI in a header', async () => {
+  it('should call the mvi-user endpoint with the Veteran\'s EIDPI in request body', async () => {
     const client = new VetsAPIClient('faketoken', 'https://example.gov');
     await client.getMVITraitsForLoa3User(samlTraitsEDIPI);
-    expect(request.get).toHaveBeenCalledWith({
+    expect(request.post).toHaveBeenCalledWith({
       url: 'https://example.gov/internal/auth/v0/mvi-user',
       json: true,
       headers: expect.objectContaining({
         apiKey: 'faketoken',
-        'x-va-idp-uuid': expect.any(String),
-        'x-va-user-email': expect.any(String),
-        'x-va-dslogon-edipi': expect.any(String),
-        'x-va-first-name': expect.any(String),
-        'x-va-middle-name': expect.any(String),
-        'x-va-last-name': expect.any(String),
-        'x-va-dob': expect.any(String),
-        'x-va-gender': expect.any(String),
-        'x-va-level-of-assurance': '3',
+      }),
+      body: expect.objectContaining({
+        idp_uuid: samlTraitsEDIPI.uuid,
+        user_email: samlTraitsEDIPI.email,
+        dslogon_edipi: samlTraitsEDIPI.edipi,
+        first_name: samlTraitsEDIPI.firstName,
+        middle_name: samlTraitsEDIPI.middleName,
+        last_name: samlTraitsEDIPI.lastName,
+        dob: samlTraitsEDIPI.dateOfBirth,
+        gender: samlTraitsEDIPI.gender,
+        level_of_assurance: '3',
       }),
     });
   });
 
-  it('should call the mvi-user endpoint with the Veteran\'s icn in headers', async () => {
+  it('should call the mvi-user endpoint with the Veteran\'s icn in request body', async () => {
     const client = new VetsAPIClient('faketoken', 'https://example.gov');
     await client.getMVITraitsForLoa3User(samlTraitsICN);
-    expect(request.get).toHaveBeenCalledWith({
+    expect(request.post).toHaveBeenCalledWith({
       url: 'https://example.gov/internal/auth/v0/mvi-user',
       json: true,
       headers: expect.objectContaining({
         apiKey: 'faketoken',
-        'x-va-idp-uuid': expect.any(String),
-        'x-va-user-email': expect.any(String),
-        'x-va-mhv-icn': expect.any(String),
-        'x-va-level-of-assurance': '3',
+      }),
+      body: expect.objectContaining({
+        idp_uuid: samlTraitsICN.uuid,
+        user_email: samlTraitsICN.email,
+        mhv_icn: samlTraitsICN.icn,
+        level_of_assurance: '3',
       }),
     });
   });
 
-  it('should call the mvi-user endpoint with the Veteran\'s PII in headers', async () => {
+  it('should call the mvi-user endpoint with the Veteran\'s PII in request body', async () => {
     const client = new VetsAPIClient('faketoken', 'https://example.gov');
     await client.getMVITraitsForLoa3User(samlTraits);
-    expect(request.get).toHaveBeenCalledWith({
+    expect(request.post).toHaveBeenCalledWith({
       url: 'https://example.gov/internal/auth/v0/mvi-user',
       json: true,
       headers: expect.objectContaining({
         apiKey: 'faketoken',
-        'x-va-idp-uuid': expect.any(String),
-        'x-va-user-email': expect.any(String),
-        'x-va-ssn': expect.any(String),
-        'x-va-first-name': expect.any(String),
-        'x-va-middle-name': expect.any(String),
-        'x-va-last-name': expect.any(String),
-        'x-va-dob': expect.any(String),
-        'x-va-gender': expect.any(String),
-        'x-va-level-of-assurance': '3',
+      }),
+      body: expect.objectContaining({
+        idp_uuid: samlTraits.uuid,
+        user_email: samlTraits.email,
+        ssn: samlTraits.ssn,
+        first_name: samlTraits.firstName,
+        middle_name: samlTraits.middleName,
+        last_name: samlTraits.lastName,
+        dob: samlTraits.dateOfBirth,
+        gender: samlTraits.gender,
+        level_of_assurance: '3',
       }),
     });
   });

--- a/saml-proxy/src/VetsAPIClient.ts
+++ b/saml-proxy/src/VetsAPIClient.ts
@@ -27,24 +27,29 @@ export class VetsAPIClient {
   public async getMVITraitsForLoa3User(user: SAMLUser) : Promise<{ icn: string, first_name: string, last_name: string }> {
     const headers = {
       'apiKey': this.token,
-      'x-va-idp-uuid': user.uuid,
-      'x-va-user-email': user.email,
-      'x-va-dslogon-edipi': user.edipi || null,
-      'x-va-mhv-icn': user.icn || null,
-      'x-va-ssn': user.ssn || null,
-      'x-va-first-name': user.firstName || null,
-      'x-va-middle-name': user.middleName || null,
-      'x-va-last-name': user.lastName || null,
-      'x-va-dob': user.dateOfBirth || null,
-      'x-va-gender': user.gender || null,
-      'x-va-level-of-assurance': '3',
     };
+
+    const body = {
+      'idp_uuid': user.uuid,
+      'user_email': user.email,
+      'dslogon_edipi': user.edipi || null,
+      'mhv_icn': user.icn || null,
+      'ssn': user.ssn || null,
+      'first_name': user.firstName || null,
+      'middle_name': user.middleName || null,
+      'last_name': user.lastName || null,
+      'dob': user.dateOfBirth || null,
+      'gender': user.gender || null,
+      'level_of_assurance': '3',
+    };
+
     // @ts-ignore TS7017
     Object.keys(headers).forEach((key) => (headers[key] == null) && delete headers[key]);
-    const response = await request.get({
+    const response = await request.post({
       url: `${this.apiHost}${LOOKUP_PATH}`,
       json: true,
       headers,
+      body,
     });
     return response.data.attributes;
   }

--- a/saml-proxy/src/VetsAPIClient.ts
+++ b/saml-proxy/src/VetsAPIClient.ts
@@ -43,8 +43,6 @@ export class VetsAPIClient {
       'level_of_assurance': '3',
     };
 
-    // @ts-ignore TS7017
-    Object.keys(headers).forEach((key) => (headers[key] == null) && delete headers[key]);
     const response = await request.post({
       url: `${this.apiHost}${LOOKUP_PATH}`,
       json: true,


### PR DESCRIPTION
… for UTF-8 - 1380

## Overview 

Completes [1380](https://github.com/department-of-veterans-affairs/vets-contrib/issues/1380) on the SAML proxy side.

Changes `VetsAPIClient.ts` to use the `mvi_users#search` POST action instead of the `mvi_users#show` GET action to look up users in MVI.

This depends on the [corresponding Vets API PR](https://github.com/department-of-veterans-affairs/vets-api/pull/2945).

## Testing

To test, make sure that you have the correct vets-api version. If the PR linked above hasn't merged, you should checkout `origin/ml-1380-utf8-header-error`.

* Verify that you can sign into a sample app locally using OAuth with this branch of the SAML proxy and the above branch of the Vets API with user va.api.user+idme.103@gmail.com.

You can't really determine for certain that the error doesn't occur unless you're debugging with byebug or console output as a developer because it no longer crashes anyway, but it should work as expected. I've tested that the output looks as expected in the server, and other devs are welcome to do the same.