### PR TITLE
Attempt VSO Search If MVI Fails

### DIFF
--- a/saml-proxy/src/VetsAPIClient.ts
+++ b/saml-proxy/src/VetsAPIClient.ts
@@ -56,7 +56,7 @@ export class VetsAPIClient {
 
   public async getVSOSearch(firstName: string, lastName: string) : Promise<{poa: string}> {
 
-    const body = {
+    const qs = {
       'first_name': firstName,
       'last_name': lastName
     }
@@ -65,8 +65,8 @@ export class VetsAPIClient {
       url: `${this.apiHost}${VSO_SEARCH_PATH}`,
       json: true,
       headers: this.headers,
-      body,
+      qs,
     });
-    return response.data.attributes;
+    return response.data.attributes.power_of_attorney_code;
   }
 }

--- a/saml-proxy/src/VetsAPIClient.ts
+++ b/saml-proxy/src/VetsAPIClient.ts
@@ -54,7 +54,7 @@ export class VetsAPIClient {
     return response.data.attributes;
   }
 
-  public async getVSOSearch(firstName: String, lastName: String) : Promise<{poa: string}> {
+  public async getVSOSearch(firstName: string, lastName: string) : Promise<{poa: string}> {
 
     const body = {
       'first_name': firstName,

--- a/saml-proxy/src/VetsAPIClient.ts
+++ b/saml-proxy/src/VetsAPIClient.ts
@@ -14,7 +14,7 @@ export interface SAMLUser {
 }
 
 const MVI_PATH = '/internal/auth/v0/mvi-user';
-const VSO_SEARCH_PATH = '/services/veteran/v0/representatives/search';
+const VSO_SEARCH_PATH = '/services/veteran/v0/representatives/find_rep';
 
 export class VetsAPIClient {
   token: string;
@@ -67,6 +67,6 @@ export class VetsAPIClient {
       headers: this.headers,
       qs,
     });
-    return response.data.attributes.power_of_attorney_code;
+    return response.data.attributes
   }
 }

--- a/saml-proxy/src/VetsAPIClient.ts
+++ b/saml-proxy/src/VetsAPIClient.ts
@@ -13,7 +13,7 @@ export interface SAMLUser {
   icn?: string;
 }
 
-const LOOKUP_PATH = '/internal/auth/v0/mvi-user';
+const MVI_PATH = '/internal/auth/v0/mvi-user';
 
 export class VetsAPIClient {
   token: string;
@@ -44,7 +44,7 @@ export class VetsAPIClient {
     };
 
     const response = await request.post({
-      url: `${this.apiHost}${LOOKUP_PATH}`,
+      url: `${this.apiHost}${MVI_PATH}`,
       json: true,
       headers,
       body,

--- a/saml-proxy/src/VetsAPIClient.ts
+++ b/saml-proxy/src/VetsAPIClient.ts
@@ -14,20 +14,22 @@ export interface SAMLUser {
 }
 
 const MVI_PATH = '/internal/auth/v0/mvi-user';
+const VSO_SEARCH_PATH = '/services/veteran/v0/representatives/search';
 
 export class VetsAPIClient {
   token: string;
   apiHost: string;
+  headers: object;
 
   constructor(token: string, apiHost: string) {
     this.token = token;
     this.apiHost = apiHost;
+    this.headers = {
+      'apiKey': this.token,
+    };
   }
 
   public async getMVITraitsForLoa3User(user: SAMLUser) : Promise<{ icn: string, first_name: string, last_name: string }> {
-    const headers = {
-      'apiKey': this.token,
-    };
 
     const body = {
       'idp_uuid': user.uuid,
@@ -46,7 +48,23 @@ export class VetsAPIClient {
     const response = await request.post({
       url: `${this.apiHost}${MVI_PATH}`,
       json: true,
-      headers,
+      headers: this.headers,
+      body,
+    });
+    return response.data.attributes;
+  }
+
+  public async getVSOSearch(firstName: String, lastName: String) : Promise<{poa: string}> {
+
+    const body = {
+      'first_name': firstName,
+      'last_name': lastName
+    }
+
+    const response = await request.get({
+      url: `${this.apiHost}${VSO_SEARCH_PATH}`,
+      json: true,
+      headers: this.headers,
       body,
     });
     return response.data.attributes;

--- a/saml-proxy/src/routes/acsHandlers.test.ts
+++ b/saml-proxy/src/routes/acsHandlers.test.ts
@@ -180,7 +180,7 @@ describe('loadICN', () => {
     expect(req.user.claims.icn).toEqual('anICN');
   });
 
-  it('should render error page when getMVITraitsForLoa3User errors', async () => {
+  it('should render error page when getMVITraitsForLoa3User errors and getVSOSearch errors', async () => {
     const nextFn = jest.fn();
     const render = jest.fn();
     const req = {
@@ -193,6 +193,7 @@ describe('loadICN', () => {
     err.name = 'StatusCodeError';
     err.statusCode = '404';
     req.vetsAPIClient.getMVITraitsForLoa3User.mockRejectedValueOnce(err);
+    req.vetsAPIClient.getVSOSearch.mockRejectedValueOnce(err);
     await handlers.loadICN(req, { render }, nextFn);
     expect(render).toHaveBeenCalled();
   });

--- a/saml-proxy/src/routes/acsHandlers.ts
+++ b/saml-proxy/src/routes/acsHandlers.ts
@@ -6,7 +6,7 @@ import { NextFunction, Response } from "express";
 import assignIn from 'lodash.assignin';
 import samlp from "samlp"; import * as url from "url";
 
-const missingUserTemplate = (error: any) => {
+const unknownUsersErrorTemplate = (error: any) => {
   // `error` comes from:
   // https://github.com/request/promise-core/blob/master/lib/errors.js
 
@@ -67,7 +67,7 @@ export const loadICN = async (req: IConfiguredRequest, res: Response, next: Next
       await req.vetsAPIClient.getVSOSearch(req.user.claims.firstName, req.user.claims.lastName);
       next();
     } catch (error) {
-      res.render(missingUserTemplate(mviError), {});
+      res.render(unknownUsersErrorTemplate(mviError), {});
     }
   }
 };

--- a/saml-proxy/src/routes/acsHandlers.ts
+++ b/saml-proxy/src/routes/acsHandlers.ts
@@ -6,7 +6,7 @@ import { NextFunction, Response } from "express";
 import assignIn from 'lodash.assignin';
 import samlp from "samlp"; import * as url from "url";
 
-const mviErrorTemplate = (error: any) => {
+const missingUserTemplate = (error: any) => {
   // `error` comes from:
   // https://github.com/request/promise-core/blob/master/lib/errors.js
 
@@ -64,11 +64,10 @@ export const loadICN = async (req: IConfiguredRequest, res: Response, next: Next
     const mviError = error;
 
     try  {
-      const { poa } = await req.vetsAPIClient.getVSOSearch(req.user.claims.firstName, req.user.claims.lastName);
-      req.user.claims.poa = poa;
+      await req.vetsAPIClient.getVSOSearch(req.user.claims.firstName, req.user.claims.lastName);
       next();
     } catch (error) {
-      res.render(mviErrorTemplate(mviError), {});
+      res.render(missingUserTemplate(mviError), {});
     }
   }
 };

--- a/saml-proxy/src/routes/acsHandlers.ts
+++ b/saml-proxy/src/routes/acsHandlers.ts
@@ -61,7 +61,16 @@ export const loadICN = async (req: IConfiguredRequest, res: Response, next: Next
     req.user.claims.lastName = last_name;
     next();
   } catch (error) {
-    res.render(mviErrorTemplate(error), {});
+    const mviError = error;
+
+    try  {
+      const { poa } = await req.vetsAPIClient.getVSOSearch(req.user.claims.firstName, req.user.claims.lastName);
+      req.user.claims.poa = poa;
+      next();
+    } catch (error) {
+      console.log(error);
+      res.render(mviErrorTemplate(mviError), {});
+    }
   }
 };
 

--- a/saml-proxy/src/routes/acsHandlers.ts
+++ b/saml-proxy/src/routes/acsHandlers.ts
@@ -68,7 +68,6 @@ export const loadICN = async (req: IConfiguredRequest, res: Response, next: Next
       req.user.claims.poa = poa;
       next();
     } catch (error) {
-      console.log(error);
       res.render(mviErrorTemplate(mviError), {});
     }
   }


### PR DESCRIPTION
In order to support VSO users in the oauth flow, we need to run a check to see if they exist if MVI fails. This should allow VSO uses to flow through like normal.

resolves https://github.com/department-of-veterans-affairs/vets-contrib/issues/1823

This is dependent on: https://github.com/department-of-veterans-affairs/vets-api/pull/2991 && https://github.com/department-of-veterans-affairs/vets-contrib/issues/1863