### PR TITLE
Use req.flash properly in passport.authenticate()

### DIFF
--- a/saml-proxy/package-lock.json
+++ b/saml-proxy/package-lock.json
@@ -1942,6 +1942,11 @@
         "xdg-basedir": "^3.0.0"
       }
     },
+    "connect-flash": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/connect-flash/-/connect-flash-0.1.1.tgz",
+      "integrity": "sha1-2GMPJtlaf4UfmVax6MxnMvO2qjA="
+    },
     "console-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
@@ -5576,9 +5581,9 @@
       }
     },
     "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "morgan": {
       "version": "1.9.1",
@@ -7239,7 +7244,7 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         },
         "ejs": {
@@ -7247,21 +7252,10 @@
           "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
           "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
         },
-        "xml-crypto": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-0.10.1.tgz",
-          "integrity": "sha1-+DL3TM9W8kr8rhFjofyrRNlndKg=",
-          "requires": {
-            "xmldom": "=0.1.19",
-            "xpath.js": ">=0.0.3"
-          },
-          "dependencies": {
-            "xmldom": {
-              "version": "0.1.19",
-              "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
-              "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw="
-            }
-          }
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         },
         "xml-encryption": {
           "version": "0.11.2",
@@ -7276,11 +7270,11 @@
           },
           "dependencies": {
             "async": {
-              "version": "2.6.1",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-              "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+              "version": "2.6.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+              "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
               "requires": {
-                "lodash": "^4.17.10"
+                "lodash": "^4.17.11"
               }
             },
             "xpath": {

--- a/saml-proxy/package.json
+++ b/saml-proxy/package.json
@@ -64,6 +64,7 @@
     "@types/request": "^2.48.1",
     "@types/request-promise-native": "^1.0.15",
     "body-parser": "~1.18.3",
+    "connect-flash": "^0.1.1",
     "cookie-parser": "~1.4.3",
     "debug": "~3.1.0",
     "event-stream": "^3.3.4",

--- a/saml-proxy/src/routes/index.js
+++ b/saml-proxy/src/routes/index.js
@@ -4,6 +4,7 @@ import bodyParser from "body-parser";
 import session from "express-session";
 import express from "express";
 import cookieParser from "cookie-parser";
+import flash from 'connect-flash';
 import logger from "morgan";
 import sassMiddleware from "node-sass-middleware";
 import tildeImporter from "node-sass-tilde-importer";
@@ -60,6 +61,7 @@ export default function configureExpress(app, argv, idpOptions, spOptions, vetsA
     name: 'idp_sid',
     cookie: { maxAge: 60000 }
   }));
+  app.use(flash());
 
   app.use(sassMiddleware({
     src: path.join(process.cwd(), "styles"),


### PR DESCRIPTION
Solves an error that existed in the SAML Proxy but wasn't exposed because it required a bad signature in the staging env (in the investigation of [vets-contrib #2069](https://github.com/department-of-veterans-affairs/vets-contrib/issues/2069)) to expose the bug. So, generally speaking, I don't think that we need to worry about this happening to an end user, unless there is another way to cause it. The reason is that ID.me will handle actual authentication errors like bad email/password combination - it never sends a `SAMLResponse` back to the SAML Proxy with a failure message to my knowledge in a successfully configured environment. Here's what ID.me does if you enter a bad password or username: 

<img width="480" alt="IDmeLoginError" src="https://user-images.githubusercontent.com/3241493/59139067-d2518600-895e-11e9-90ad-a70c9032662b.png">

Alternative solution would be to remove `this.failureFlash = true` in `SPConfig`.

There's also a lot wrong with this currently, as this fix doesn't actually make the error handler comprehensible. It still 404s because `passport.authenticate` then immediately tries to redirect to `SP_ERROR_URL`, which we specified via `this.failureRedirect` in `SPConfig`. `SP_ERROR_URL` doesn't have a route handler, though, so we should probably decide what we want that backup to look like in case something is wrong in a deployed env.