### PR TITLE
Add CORS support to metadata endpoints.

### DIFF
--- a/oauth-proxy/package-lock.json
+++ b/oauth-proxy/package-lock.json
@@ -1261,6 +1261,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "crc": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
@@ -1277,6 +1286,12 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
+    },
+    "crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "dev": true
     },
     "cssom": {
       "version": "0.3.6",

--- a/oauth-proxy/package.json
+++ b/oauth-proxy/package.json
@@ -22,6 +22,7 @@
     "@okta/okta-sdk-nodejs": "^1.2.0",
     "aws-sdk": "^2.372.0",
     "body-parser": "^1.18.3",
+    "cors": "^2.8.5",
     "express": "^4.16.4",
     "express-session": "^1.15.6",
     "jwt-decode": "^2.2.0",
@@ -32,6 +33,7 @@
     "yargs": "^12.0.5"
   },
   "devDependencies": {
-    "jest": "^24.8.0"
+    "jest": "^24.8.0",
+    "crypto": "^1.0.1"
   }
 }


### PR DESCRIPTION
This adds CORS support (both simple and pre-flight) to the metadata endpoints. This allows single page apps (including our react sample app) to auto-configure their OpenID Connect client.

Related to this ticket: https://github.com/department-of-veterans-affairs/vets-contrib/issues/1841