### PR TITLE
Upgrade express-prom-bundle to 5.1.5 and add it to oauth-proxy.

### DIFF
--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -83,7 +83,7 @@ function buildApp(config, issuer, oktaClient, dynamo, dynamoClient) {
   app.use(promBundle({
     includeMethod: true,
     includePath: true,
-    customLables: {app: 'oauth_proxy'},
+    customLabels: {app: 'oauth_proxy'},
   }));
 
   router.use([appRoutes.token], bodyParser.urlencoded({ extended: true }));

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -11,6 +11,7 @@ const { processArgs } = require('./cli')
 const okta = require('@okta/okta-sdk-nodejs');
 const morgan = require('morgan');
 const requestPromise = require('request-promise-native');
+const promBundle = require('express-prom-bundle');
 
 const appRoutes = {
   authorize: '/authorization',
@@ -79,6 +80,12 @@ function buildApp(config, issuer, oktaClient, dynamo, dynamoClient) {
   const app = express();
   const router = new express.Router();
   app.use(morgan('combined'));
+  app.use(promBundle({
+    includeMethod: true,
+    includePath: true,
+    customLables: {app: 'oauth_proxy'},
+  }));
+
   router.use([appRoutes.token], bodyParser.urlencoded({ extended: true }));
 
   const corsHandler = cors({

--- a/oauth-proxy/package-lock.json
+++ b/oauth-proxy/package-lock.json
@@ -912,6 +912,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
     "body-parser": {
       "version": "1.18.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
@@ -1725,6 +1730,15 @@
         "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      }
+    },
+    "express-prom-bundle": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/express-prom-bundle/-/express-prom-bundle-5.1.5.tgz",
+      "integrity": "sha512-tUaQUBu0r9zGYcVDpKBI2AeWimuuodaC5BSBkzLPQxRTxaKQShQNnONQSYwjLxbHfPwlCKVZlzfbB9Recnj0Vg==",
+      "requires": {
+        "on-finished": "^2.3.0",
+        "url-value-parser": "^2.0.0"
       }
     },
     "express-session": {
@@ -4699,6 +4713,14 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
+    "prom-client": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.2.tgz",
+      "integrity": "sha512-moMHqs3Z1cW1vTCvZx9Edyy96GiVBLgOtPk1fif4EyDC9Xbn2tcv090TgxZocHh5XsK3H/kfKaYY4h5MMhGrsA==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "prompts": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
@@ -5488,6 +5510,14 @@
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
     },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
+      }
+    },
     "test-exclude": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
@@ -5827,6 +5857,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+    },
+    "url-value-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/url-value-parser/-/url-value-parser-2.0.1.tgz",
+      "integrity": "sha512-bexECeREBIueboLGM3Y1WaAzQkIn+Tca/Xjmjmfd0S/hFHSCEoFkNh0/D0l9G4K74MkEP/lLFRlYnxX3d68Qgw=="
     },
     "use": {
       "version": "3.1.1",

--- a/oauth-proxy/package.json
+++ b/oauth-proxy/package.json
@@ -24,10 +24,12 @@
     "body-parser": "^1.18.3",
     "cors": "^2.8.5",
     "express": "^4.16.4",
+    "express-prom-bundle": "^5.1.5",
     "express-session": "^1.15.6",
     "jwt-decode": "^2.2.0",
     "morgan": "^1.9.1",
     "openid-client": "^2.4.5",
+    "prom-client": "^11.5.2",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
     "yargs": "^12.0.5"

--- a/saml-proxy/package-lock.json
+++ b/saml-proxy/package-lock.json
@@ -1210,6 +1210,11 @@
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
       "dev": true
     },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -6475,6 +6480,14 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
+    "prom-client": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.2.tgz",
+      "integrity": "sha512-moMHqs3Z1cW1vTCvZx9Edyy96GiVBLgOtPk1fif4EyDC9Xbn2tcv090TgxZocHh5XsK3H/kfKaYY4h5MMhGrsA==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "prompts": {
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.14.tgz",
@@ -8374,6 +8387,14 @@
         "block-stream": "*",
         "fstream": "^1.0.2",
         "inherits": "2"
+      }
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
       }
     },
     "term-size": {

--- a/saml-proxy/package-lock.json
+++ b/saml-proxy/package-lock.json
@@ -313,6 +313,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1208,11 +1209,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
       "dev": true
-    },
-    "bintrees": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
-      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
     },
     "block-stream": {
       "version": "0.0.9",
@@ -2729,12 +2725,11 @@
       }
     },
     "express-prom-bundle": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/express-prom-bundle/-/express-prom-bundle-4.2.1.tgz",
-      "integrity": "sha512-gs6l9l9zYfAobwP29v3FmESF2Yxq6BuSdhWmJ3JnkaEPceagiwyZJj2AG9DmSt8w1ZFsc91cMMjRlMI3vC/a9g==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/express-prom-bundle/-/express-prom-bundle-5.1.5.tgz",
+      "integrity": "sha512-tUaQUBu0r9zGYcVDpKBI2AeWimuuodaC5BSBkzLPQxRTxaKQShQNnONQSYwjLxbHfPwlCKVZlzfbB9Recnj0Vg==",
       "requires": {
         "on-finished": "^2.3.0",
-        "prom-client": "~11.1.1",
         "url-value-parser": "^2.0.0"
       }
     },
@@ -2963,7 +2958,7 @@
     },
     "foundation-sites": {
       "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-5.5.3.tgz",
+      "resolved": "http://registry.npmjs.org/foundation-sites/-/foundation-sites-5.5.3.tgz",
       "integrity": "sha1-ZVbrKzHN47ImYwEWvSFdldBWwKc="
     },
     "fragment-cache": {
@@ -3010,7 +3005,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3031,12 +3027,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3051,17 +3049,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3178,7 +3179,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3190,6 +3192,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3204,6 +3207,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3211,12 +3215,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3235,6 +3241,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3315,7 +3322,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3327,6 +3335,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3412,7 +3421,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3448,6 +3458,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3467,6 +3478,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3510,12 +3522,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5267,7 +5281,8 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "optional": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -6259,10 +6274,10 @@
         "passport-strategy": "^1.0.0",
         "uid2": "0.0.x",
         "valid-url": "^1.0.9",
-        "xml-crypto": "github:auth0/xml-crypto#65fa1e22c5884e45135d0bacccb99ad11e900bf1",
+        "xml-crypto": "github:auth0/xml-crypto#fix-digest",
         "xml-encryption": "0.11.0",
         "xml2js": "0.1.x",
-        "xmldom": "github:auth0/xmldom#3376bc7beb5551bf68e12b0cc6b0e3669f77d392",
+        "xmldom": "github:auth0/xmldom#v0.1.19-auth0_1",
         "xpath": "0.0.5",
         "xtend": "~2.0.3"
       },
@@ -6459,14 +6474,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-    },
-    "prom-client": {
-      "version": "11.1.3",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.1.3.tgz",
-      "integrity": "sha512-vpEQ8NltXq+lrtOYvPEoX+kvN4FG3LrIfa0/eVE8sfePDIprhV/RY7EX8u14EN4KWNjO9O70b9mNLHglSt1rzQ==",
-      "requires": {
-        "tdigest": "^0.1.1"
-      }
     },
     "prompts": {
       "version": "0.1.14",
@@ -7244,7 +7251,7 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
         },
         "ejs": {
@@ -7299,7 +7306,7 @@
         "ejs": "2.5.5",
         "flowstate": "^0.4.0",
         "querystring": "^0.2.0",
-        "saml": "git+https://github.com/edpaget/node-saml.git#1c90b77d42dbb6b5c7f1be938ce2a118e10a5fab",
+        "saml": "git+https://github.com/edpaget/node-saml.git",
         "xml-crypto": "^0.10.1",
         "xmldom": "^0.1.27",
         "xpath": "0.0.5",
@@ -8369,14 +8376,6 @@
         "inherits": "2"
       }
     },
-    "tdigest": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
-      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
-      "requires": {
-        "bintrees": "1.0.1"
-      }
-    },
     "term-size": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -8949,9 +8948,9 @@
       }
     },
     "url-value-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/url-value-parser/-/url-value-parser-2.0.0.tgz",
-      "integrity": "sha512-UHljhS0U5+3mlzYtAzr6dNhj/js0f5a7yN/Zhl7OxB7PM4Hdj8CrKYWd1bHQ5qM87LrMhwK5QNj9dI+tN2v/tA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/url-value-parser/-/url-value-parser-2.0.1.tgz",
+      "integrity": "sha512-bexECeREBIueboLGM3Y1WaAzQkIn+Tca/Xjmjmfd0S/hFHSCEoFkNh0/D0l9G4K74MkEP/lLFRlYnxX3d68Qgw=="
     },
     "use": {
       "version": "3.1.1",

--- a/saml-proxy/package.json
+++ b/saml-proxy/package.json
@@ -69,7 +69,7 @@
     "debug": "~3.1.0",
     "event-stream": "^3.3.4",
     "express": "^4.16.4",
-    "express-prom-bundle": "^4.2.1",
+    "express-prom-bundle": "^5.1.5",
     "express-session": "^1.15.6",
     "extend": "^3.0.1",
     "font-awesome": "^4.7.0",

--- a/saml-proxy/package.json
+++ b/saml-proxy/package.json
@@ -83,6 +83,7 @@
     "node-sass-tilde-importer": "^1.0.2",
     "passport": "^0.4.0",
     "passport-wsfed-saml2": "git+https://github.com/edpaget/passport-wsfed-saml2.git",
+    "prom-client": "^11.5.2",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.5",
     "samlp": "git+https://github.com/edpaget/node-samlp.git",


### PR DESCRIPTION
Adds express-prom-bundle to the oauth-proxy. Also upgrades it to 5.1.5 for the saml-proxy.

Related to: https://github.com/department-of-veterans-affairs/vets-contrib/issues/2407