### PR TITLE
vets-saml-proxy, oauth-proxy, proxy-monitor docker containers run as non-root user

### DIFF
--- a/oauth-proxy/Dockerfile
+++ b/oauth-proxy/Dockerfile
@@ -15,4 +15,5 @@ EXPOSE 7100 7100
 HEALTHCHECK --interval=1m --timeout=4s \
   CMD curl -f http://localhost:7100/oauth2/.well-known/openid-configuration || exit 1
 
+USER node
 ENTRYPOINT ["node", "index.js"]

--- a/proxy-monitor/Dockerfile
+++ b/proxy-monitor/Dockerfile
@@ -15,4 +15,5 @@ EXPOSE 7200 7200
 HEALTHCHECK --interval=1m --timeout=4s \
   CMD curl -f http://localhost:7200/health-check || exit 1
 
+USER node
 ENTRYPOINT ["node", "index.js"]

--- a/saml-proxy/Dockerfile
+++ b/saml-proxy/Dockerfile
@@ -17,4 +17,5 @@ RUN ./node_modules/.bin/tsc
 HEALTHCHECK --interval=1m --timeout=4s \
   CMD curl -f http://localhost:7000/samlproxy/idp/metadata || exit 1
 
+USER node
 ENTRYPOINT ["node", "build/app.js"]


### PR DESCRIPTION
Alpine Node Docker images contain a 'node' user which is intended to run the processes inside the Docker container. Let's use that to run the processes.