### PR TITLE
use wget instead of curl for Docker healthchecks

### DIFF
--- a/oauth-proxy/Dockerfile
+++ b/oauth-proxy/Dockerfile
@@ -13,7 +13,7 @@ ADD ./ .
 
 EXPOSE 7100 7100
 HEALTHCHECK --interval=1m --timeout=4s \
-  CMD curl -f http://localhost:7100/oauth2/.well-known/openid-configuration || exit 1
+  CMD wget localhost:7100/oauth2/.well-known/openid-configuration -q -O - > /dev/null 2>&1
 
 USER node
 ENTRYPOINT ["node", "index.js"]

--- a/proxy-monitor/Dockerfile
+++ b/proxy-monitor/Dockerfile
@@ -13,7 +13,7 @@ ADD ./ .
 
 EXPOSE 7200 7200
 HEALTHCHECK --interval=1m --timeout=4s \
-  CMD curl -f http://localhost:7200/health-check || exit 1
+  CMD wget localhost:7200/health-check -q -O - > /dev/null 2>&1
 
 USER node
 ENTRYPOINT ["node", "index.js"]

--- a/saml-proxy/Dockerfile
+++ b/saml-proxy/Dockerfile
@@ -15,7 +15,7 @@ EXPOSE 7000 7000
 
 RUN ./node_modules/.bin/tsc
 HEALTHCHECK --interval=1m --timeout=4s \
-  CMD curl -f http://localhost:7000/samlproxy/idp/metadata || exit 1
+  CMD wget localhost:7000/samlproxy/idp/metadata -q -O - > /dev/null 2>&1
 
 USER node
 ENTRYPOINT ["node", "build/app.js"]


### PR DESCRIPTION
fixes: https://github.com/department-of-veterans-affairs/vets-contrib/issues/2525

Alpine node docker containers contain wget, but not curl. Rather than install another package (increase size and attack surface) let's use wget for the healthchecks.

the replacement for this is not 1:1, as curl has different options.

`wget URL -q -O - > /dev/null 2>&1` will take care of it and leave the exit status 0 on success and 1 on failure. `-q` is silent mode, and `-O - > /dev/null 2>&1` causes the output from the wget to be redirected to the bitbucket.

tested inside a proxy-monitor container:
```
/opt/app $ wget localhost:7200/health-check -q -O - > /dev/null 2>&1
/opt/app $ echo $?
0
/opt/app $ wget localhost:7200/health-checak -q -O - > /dev/null 2>&1
/opt/app $ echo $?
1
```