### PR TITLE
Increase headersTimeout from default 40s value

### DIFF
--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -321,6 +321,7 @@ function startApp(config, issuer) {
   const env = app.get('env');
   const server = app.listen(config.port, () => console.log(`OAuth Proxy listening on port ${config.port} in ${env} mode!`));
   server.keepAliveTimeout = 75000;
+  server.headersTimeout = 75000;
   return null;
 }
 

--- a/saml-proxy/src/app.js
+++ b/saml-proxy/src/app.js
@@ -71,6 +71,7 @@ function runServer(argv) {
       console.log('starting proxy server on port %s in %s mode', app.get('port'), env);
 
       httpServer.keepAliveTimeout = 75000;
+      httpServer.headersTimeout = 75000;
       httpServer.listen(app.get('port'), function() {
         const scheme   = argv.idpHttps ? 'https' : 'http',
               address  = httpServer.address(),


### PR DESCRIPTION
Hopefully this resolves the 504 issue outlined in https://github.com/department-of-veterans-affairs/vets-contrib/issues/1094.

See my [comment on the issue](https://github.com/department-of-veterans-affairs/vets-contrib/issues/1094#issuecomment-517833070) for my justification of doing this without knowing whether it will help.

Also, 75s is an arbitrary choice, just keeping it the same as the keepalive setting. I don't really have any information to make a better choice, so speak up if you do!