### PR TITLE
Change build name to saml-proxy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
           commit = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
         }
 
-        build job: 'builds/vets-saml-proxy', parameters: [
+        build job: 'builds/saml-proxy', parameters: [
           booleanParam(name: 'notify_slack', value: true),
           stringParam(name: 'ref', value: commit),
           booleanParam(name: 'release', value: false),


### PR DESCRIPTION
Update build name from `vets-saml-proxy` to `saml-proxy` after https://github.com/department-of-veterans-affairs/devops/pull/5370 is merged.