### PR TITLE
SAML and OAuth proxies configured as such

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ To being you'll want to create a `dev-config.json` in the oauth-proxy subdirecto
 JSON object containing fields that corresponesd to the options document by the `--help` option. Once you've
 created that config you can run `npm start` to run the OAuth proxy with the code changes. 
 
-If you're a VA developer, you can look at the [vets-contrib](https://github.com/department-of-veterans-affairs/vets-contrib/tree/master/Developer%20Process/SAML%20Proxy/OAuthSetup.md) repo for 
-specific values for using our dev Okta environment. 
+If you're a VA developer, you can look at the [vets-contrib](https://github.com/department-of-veterans-affairs/vets-contrib/blob/master/practice-areas/engineering/Developer%20Process/SAML%20Proxy/OAuthSetup.md) repo for specific values for using our dev Okta environment.
 
 You'll also want to setup a local instance of DynamoDB either by running `docker-compose` to start the proxy or 
 by downloading and running it following [Amazon's instructions](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html).

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -79,6 +79,9 @@ function buildApp(config, issuer, oktaClient, dynamo, dynamoClient) {
 
   const app = express();
   const router = new express.Router();
+  // Express needs to know it is being ran behind a trusted proxy. Setting 'trust proxy' to true does a few things
+  // but notably sets req.ip = 'X-Forwarded-for'. See http://expressjs.com/en/guide/behind-proxies.html
+  app.set('trust proxy', true)
   app.use(morgan('combined'));
   app.use(promBundle({
     includeMethod: true,

--- a/saml-proxy/src/routes/index.js
+++ b/saml-proxy/src/routes/index.js
@@ -32,6 +32,9 @@ export default function configureExpress(app, argv, idpOptions, spOptions, vetsA
   });
   app.set('port', process.env.PORT || argv.port);
   app.set('views', path.join(process.cwd(), './views'));
+  // Express needs to know it is being ran behind a trusted proxy. Setting 'trust proxy' to true does a few things
+  // but notably sets req.ip = 'X-Forwarded-for'. See http://expressjs.com/en/guide/behind-proxies.html
+  app.set('trust proxy', true)
 
   /**
    * View Engine


### PR DESCRIPTION
Express will use the X-Forwarded-By header for a requests IP address if told to do so. See http://expressjs.com/en/guide/behind-proxies.html. Also fixed a broken link.