### PR TITLE
Add sentry to oauth/saml proxies

### DIFF
--- a/oauth-proxy/cli.js
+++ b/oauth-proxy/cli.js
@@ -56,6 +56,16 @@ function processArgs() {
       idp: {
         description: 'Okta IDP identifier to be added as a query param (idp) if not specified by user in authorize request'
       },
+      sentry_dsn: {
+        description: 'URL of the sentry project to send errors',
+        required: false,
+        string: true
+      },
+      sentry_environment: {
+        description: 'Environment of the Sentry project',
+        required: false,
+        string: true
+      },
     })
     .wrap(yargs.terminalWidth())
     .argv;

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -12,6 +12,7 @@ const okta = require('@okta/okta-sdk-nodejs');
 const morgan = require('morgan');
 const requestPromise = require('request-promise-native');
 const promBundle = require('express-prom-bundle');
+const Sentry = require('@sentry/node');
 
 const appRoutes = {
   authorize: '/authorization',
@@ -72,7 +73,31 @@ function buildMetadataRewriteTable(config, appRoutes) {
   };
 }
 
+function filterProperty(object, property) {
+  if (property in object) {
+    object[property] = '[Filtered]';
+  }
+}
+
 function buildApp(config, issuer, oktaClient, dynamo, dynamoClient) {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.SENTRY_ENVIRONMENT,
+    beforeSend(event) {
+      filterProperty(event.request, 'cookies');
+      filterProperty(event.request.headers, 'cookie');
+      filterProperty(event.request.headers, 'authorization');
+      return event;
+    },
+    shouldHandleError(error) {
+      // This is the default for Sentry (above 500s are sent to Sentry). I think there is a discussion to be had on what
+      // errors we want to make it to Sentry. I could see us passing all errors through to Sentry, 4xx and 5xx
+      if (error.status >= 500) {
+        return true
+      }
+      return false
+    }
+  });
   const { well_known_base_path } = config;
   const redirect_uri = `${config.host}${well_known_base_path}${appRoutes.redirect}`;
   const metadataRewrite = buildMetadataRewriteTable(config, appRoutes);
@@ -82,6 +107,9 @@ function buildApp(config, issuer, oktaClient, dynamo, dynamoClient) {
   // Express needs to know it is being ran behind a trusted proxy. Setting 'trust proxy' to true does a few things
   // but notably sets req.ip = 'X-Forwarded-for'. See http://expressjs.com/en/guide/behind-proxies.html
   app.set('trust proxy', true)
+  app.use(Sentry.Handlers.requestHandler({
+    user: false,
+  }));
   app.use(morgan('combined'));
   app.use(promBundle({
     includeMethod: true,
@@ -287,6 +315,7 @@ function buildApp(config, issuer, oktaClient, dynamo, dynamoClient) {
   // Error handlers. Keep as last middleware
   // If we have error and description as query params display them, otherwise go to the
   // catchall error handler
+  app.use(Sentry.Handlers.errorHandler());
   app.use(function (err, req, res, next) {
     const { error, error_description } = req.query;
     if (error && error_description) {

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -80,24 +80,27 @@ function filterProperty(object, property) {
 }
 
 function buildApp(config, issuer, oktaClient, dynamo, dynamoClient) {
-  Sentry.init({
-    dsn: process.env.SENTRY_DSN,
-    environment: process.env.SENTRY_ENVIRONMENT,
-    beforeSend(event) {
-      filterProperty(event.request, 'cookies');
-      filterProperty(event.request.headers, 'cookie');
-      filterProperty(event.request.headers, 'authorization');
-      return event;
-    },
-    shouldHandleError(error) {
-      // This is the default for Sentry (above 500s are sent to Sentry). I think there is a discussion to be had on what
-      // errors we want to make it to Sentry. I could see us passing all errors through to Sentry, 4xx and 5xx
-      if (error.status >= 500) {
-        return true
+  const useSentry = typeof process.env.SENTRY_DSN !== 'undefined' && typeof process.env.SENTRY_ENVIRONMENT !== 'undefined';
+  if (useSentry) {
+    Sentry.init({
+      dsn: process.env.SENTRY_DSN,
+      environment: process.env.SENTRY_ENVIRONMENT,
+      beforeSend(event) {
+        filterProperty(event.request, 'cookies');
+        filterProperty(event.request.headers, 'cookie');
+        filterProperty(event.request.headers, 'authorization');
+        return event;
+      },
+      shouldHandleError(error) {
+        // This is the default for Sentry (above 500s are sent to Sentry). I think there is a discussion to be had on what
+        // errors we want to make it to Sentry. I could see us passing all errors through to Sentry, 4xx and 5xx
+        if (error.status >= 500) {
+          return true
+        }
+        return false
       }
-      return false
-    }
-  });
+    });
+  }
   const { well_known_base_path } = config;
   const redirect_uri = `${config.host}${well_known_base_path}${appRoutes.redirect}`;
   const metadataRewrite = buildMetadataRewriteTable(config, appRoutes);
@@ -106,10 +109,12 @@ function buildApp(config, issuer, oktaClient, dynamo, dynamoClient) {
   const router = new express.Router();
   // Express needs to know it is being ran behind a trusted proxy. Setting 'trust proxy' to true does a few things
   // but notably sets req.ip = 'X-Forwarded-for'. See http://expressjs.com/en/guide/behind-proxies.html
-  app.set('trust proxy', true)
-  app.use(Sentry.Handlers.requestHandler({
-    user: false,
-  }));
+  app.set('trust proxy', true);
+  if (useSentry) {
+    app.use(Sentry.Handlers.requestHandler({
+      user: false,
+    }));
+  }
   app.use(morgan('combined'));
   app.use(promBundle({
     includeMethod: true,
@@ -315,7 +320,9 @@ function buildApp(config, issuer, oktaClient, dynamo, dynamoClient) {
   // Error handlers. Keep as last middleware
   // If we have error and description as query params display them, otherwise go to the
   // catchall error handler
-  app.use(Sentry.Handlers.errorHandler());
+  if (useSentry) {
+    app.use(Sentry.Handlers.errorHandler());
+  }
   app.use(function (err, req, res, next) {
     const { error, error_description } = req.query;
     if (error && error_description) {

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -96,7 +96,7 @@ function buildApp(config, issuer, oktaClient, dynamo, dynamoClient) {
       shouldHandleError(error) {
         // This is the default for Sentry (above 500s are sent to Sentry). I think there is a discussion to be had on what
         // errors we want to make it to Sentry. I could see us passing all errors through to Sentry, 4xx and 5xx
-        if (error.status >= 500) {
+        if (error.status >= 400) {
           return true
         }
         return false

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -80,15 +80,17 @@ function filterProperty(object, property) {
 }
 
 function buildApp(config, issuer, oktaClient, dynamo, dynamoClient) {
-  const useSentry = typeof process.env.SENTRY_DSN !== 'undefined' && typeof process.env.SENTRY_ENVIRONMENT !== 'undefined';
+  const useSentry = typeof config.sentry_dsn !== 'undefined' && typeof config.sentry_environment !== 'undefined';
   if (useSentry) {
     Sentry.init({
-      dsn: process.env.SENTRY_DSN,
-      environment: process.env.SENTRY_ENVIRONMENT,
+      dsn: config.sentry_dsn,
+      environment: config.sentry_environment,
       beforeSend(event) {
-        filterProperty(event.request, 'cookies');
-        filterProperty(event.request.headers, 'cookie');
-        filterProperty(event.request.headers, 'authorization');
+        if (event.request) {
+          filterProperty(event.request, 'cookies');
+          filterProperty(event.request.headers, 'cookie');
+          filterProperty(event.request.headers, 'authorization');
+        }
         return event;
       },
       shouldHandleError(error) {

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -80,7 +80,7 @@ function filterProperty(object, property) {
 }
 
 function buildApp(config, issuer, oktaClient, dynamo, dynamoClient) {
-  const useSentry = typeof config.sentry_dsn !== 'undefined' && typeof config.sentry_environment !== 'undefined';
+  const useSentry = config.sentry_dsn !== undefined && config.sentry_environment !== undefined;
   if (useSentry) {
     Sentry.init({
       dsn: config.sentry_dsn,

--- a/oauth-proxy/package-lock.json
+++ b/oauth-proxy/package-lock.json
@@ -457,6 +457,67 @@
         "json-stable-stringify": "1.0.1"
       }
     },
+    "@sentry/core": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.7.1.tgz",
+      "integrity": "sha512-AOn3k3uVWh2VyajcHbV9Ta4ieDIeLckfo7UMLM+CTk2kt7C89SayDGayJMSsIrsZlL4qxBoLB9QY4W2FgAGJrg==",
+      "requires": {
+        "@sentry/hub": "5.7.1",
+        "@sentry/minimal": "5.7.1",
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.7.1.tgz",
+      "integrity": "sha512-evGh323WR073WSBCg/RkhlUmCQyzU0xzBzCZPscvcoy5hd4SsLE6t9Zin+WACHB9JFsRQIDwNDn+D+pj3yKsig==",
+      "requires": {
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.7.1.tgz",
+      "integrity": "sha512-nS/Dg+jWAZtcxQW8wKbkkw4dYvF6uyY/vDiz/jFCaux0LX0uhgXAC9gMOJmgJ/tYBLJ64l0ca5LzpZa7BMJQ0g==",
+      "requires": {
+        "@sentry/hub": "5.7.1",
+        "@sentry/types": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.7.1.tgz",
+      "integrity": "sha512-hVM10asFStrOhYZzMqFM7V1lrHkr1ydc2n/SFG0ZmIQxfTjCVElyXV/BJASIdqadM1fFIvvtD/EfgkTcZmub1g==",
+      "requires": {
+        "@sentry/core": "5.7.1",
+        "@sentry/hub": "5.7.1",
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.7.1",
+        "cookie": "^0.3.1",
+        "https-proxy-agent": "^3.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.7.1.tgz",
+      "integrity": "sha512-tbUnTYlSliXvnou5D4C8Zr+7/wJrHLbpYX1YkLXuIJRU0NSi81bHMroAuHWILcQKWhVjaV/HZzr7Y/hhWtbXVQ=="
+    },
+    "@sentry/utils": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.7.1.tgz",
+      "integrity": "sha512-nhirUKj/qFLsR1i9kJ5BRvNyzdx/E2vorIsukuDrbo8e3iZ11JMgCOVrmC8Eq9YkHBqgwX4UnrPumjFyvGMZ2Q==",
+      "requires": {
+        "@sentry/types": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
@@ -584,6 +645,14 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
       "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
       "dev": true
+    },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
     },
     "aggregate-error": {
       "version": "1.0.0",
@@ -1553,6 +1622,14 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
       "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -2772,6 +2849,30 @@
         "sshpk": "^1.7.0"
       }
     },
+    "https-proxy-agent": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+      "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+      "requires": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
@@ -3957,6 +4058,11 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "make-dir": {
       "version": "2.1.0",
@@ -5630,6 +5736,11 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/oauth-proxy/package.json
+++ b/oauth-proxy/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/department-of-veterans-affairs/oauth-proxy#readme",
   "dependencies": {
     "@okta/okta-sdk-nodejs": "^1.2.0",
+    "@sentry/node": "^5.7.1",
     "aws-sdk": "^2.372.0",
     "body-parser": "^1.18.3",
     "cors": "^2.8.5",

--- a/saml-proxy/package-lock.json
+++ b/saml-proxy/package-lock.json
@@ -51,6 +51,67 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.6.3.tgz",
       "integrity": "sha512-s5PLdI9NYgjBvfrv6rhirPHlAHWx+Sfo/IjsAeiXYfmemC/GSjwsyz1wLnGPazbLPXWfk62ks980o9AmsxYUEQ=="
     },
+    "@sentry/core": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.7.1.tgz",
+      "integrity": "sha512-AOn3k3uVWh2VyajcHbV9Ta4ieDIeLckfo7UMLM+CTk2kt7C89SayDGayJMSsIrsZlL4qxBoLB9QY4W2FgAGJrg==",
+      "requires": {
+        "@sentry/hub": "5.7.1",
+        "@sentry/minimal": "5.7.1",
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.7.1.tgz",
+      "integrity": "sha512-evGh323WR073WSBCg/RkhlUmCQyzU0xzBzCZPscvcoy5hd4SsLE6t9Zin+WACHB9JFsRQIDwNDn+D+pj3yKsig==",
+      "requires": {
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.7.1.tgz",
+      "integrity": "sha512-nS/Dg+jWAZtcxQW8wKbkkw4dYvF6uyY/vDiz/jFCaux0LX0uhgXAC9gMOJmgJ/tYBLJ64l0ca5LzpZa7BMJQ0g==",
+      "requires": {
+        "@sentry/hub": "5.7.1",
+        "@sentry/types": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.7.1.tgz",
+      "integrity": "sha512-hVM10asFStrOhYZzMqFM7V1lrHkr1ydc2n/SFG0ZmIQxfTjCVElyXV/BJASIdqadM1fFIvvtD/EfgkTcZmub1g==",
+      "requires": {
+        "@sentry/core": "5.7.1",
+        "@sentry/hub": "5.7.1",
+        "@sentry/types": "5.7.1",
+        "@sentry/utils": "5.7.1",
+        "cookie": "^0.3.1",
+        "https-proxy-agent": "^3.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.7.1.tgz",
+      "integrity": "sha512-tbUnTYlSliXvnou5D4C8Zr+7/wJrHLbpYX1YkLXuIJRU0NSi81bHMroAuHWILcQKWhVjaV/HZzr7Y/hhWtbXVQ=="
+    },
+    "@sentry/utils": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.7.1.tgz",
+      "integrity": "sha512-nhirUKj/qFLsR1i9kJ5BRvNyzdx/E2vorIsukuDrbo8e3iZ11JMgCOVrmC8Eq9YkHBqgwX4UnrPumjFyvGMZ2Q==",
+      "requires": {
+        "@sentry/types": "5.7.1",
+        "tslib": "^1.9.3"
+      }
+    },
     "@types/body-parser": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
@@ -305,6 +366,14 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.0.tgz",
       "integrity": "sha512-ugTb7Lq7u4GfWSqqpwE0bGyoBZNMTok/zDBXxfEG0QM50jNlGhIWjRC1pPN7bvV1anhF+bs+/gNcRw+o55Evbg=="
+    },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
     },
     "ajv": {
       "version": "5.5.2",
@@ -2569,6 +2638,19 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -3039,7 +3121,7 @@
     },
     "foundation-sites": {
       "version": "5.5.3",
-      "resolved": "http://registry.npmjs.org/foundation-sites/-/foundation-sites-5.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-5.5.3.tgz",
       "integrity": "sha1-ZVbrKzHN47ImYwEWvSFdldBWwKc="
     },
     "fragment-cache": {
@@ -4046,6 +4128,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
       "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
+    },
+    "https-proxy-agent": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-3.0.1.tgz",
+      "integrity": "sha512-+ML2Rbh6DAuee7d07tYGEKOEi2voWPUGan+ExdPbPW6Z3svq+JCqr0v8WmKPOkz1vOVykPCBSuobe7G8GJUtVg==",
+      "requires": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
+      }
     },
     "iconv-lite": {
       "version": "0.4.23",
@@ -5424,6 +5515,11 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "make-dir": {
       "version": "1.3.0",
@@ -8792,6 +8888,11 @@
           "dev": true
         }
       }
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tty-browserify": {
       "version": "0.0.1",

--- a/saml-proxy/package.json
+++ b/saml-proxy/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@department-of-veterans-affairs/formation": "^3.0.0",
+    "@sentry/node": "^5.7.1",
     "@types/express-session": "^1.15.11",
     "@types/lodash.assignin": "^4.2.4",
     "@types/morgan": "^1.7.36",

--- a/saml-proxy/src/cli/index.js
+++ b/saml-proxy/src/cli/index.js
@@ -127,6 +127,16 @@ export function processArgs() {
         required: false,
         string: true
       },
+      sentryDSN: {
+        description: 'URL of the sentry project to send errors',
+        required: false,
+        string: true
+      },
+      sentryEnvironment: {
+        description: 'Environment of the Sentry project',
+        required: false,
+        string: true
+      },
       spProtocol: {
         description: 'Federation Protocol',
         required: true,

--- a/saml-proxy/src/routes/index.js
+++ b/saml-proxy/src/routes/index.js
@@ -53,7 +53,7 @@ export default function configureExpress(app, argv, idpOptions, spOptions, vetsA
       shouldHandleError(error) {
         // This is the default for Sentry (above 500s are sent to Sentry). I think there is a discussion to be had on what
         // errors we want to make it to Sentry. I could see us passing all errors through to Sentry, 4xx and 5xx
-        if (error.status >= 500) {
+        if (error.status >= 400) {
           return true
         }
         return false

--- a/saml-proxy/src/routes/index.js
+++ b/saml-proxy/src/routes/index.js
@@ -17,8 +17,44 @@ import { getParticipant } from "./handlers";
 import { VetsAPIClient } from "../VetsAPIClient";
 
 import promBundle from 'express-prom-bundle';
+import * as Sentry from '@sentry/node';
+
+function filterProperty(object, property) {
+  if (property in object) {
+    object[property] = '[Filtered]';
+  }
+}
 
 export default function configureExpress(app, argv, idpOptions, spOptions, vetsAPIOptions) {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.SENTRY_ENVIRONMENT,
+    beforeSend(event) {
+      filterProperty(event.request, 'cookies');
+      filterProperty(event.request.headers, 'cookie');
+      filterProperty(event.request.headers, 'authorization');
+
+      let data;
+      try {
+        data = JSON.parse(event.request.data);
+        filterProperty(data, 'SAMLResponse');
+        filterProperty(data, 'SAMLRequest');
+      } catch (err) {
+        data = event.request.data;
+      }
+
+      event.request.data = data;
+      return event;
+    },
+    shouldHandleError(error) {
+      // This is the default for Sentry (above 500s are sent to Sentry). I think there is a discussion to be had on what
+      // errors we want to make it to Sentry. I could see us passing all errors through to Sentry, 4xx and 5xx
+      if (error.status >= 500) {
+        return true
+      }
+      return false
+    }
+  });
   const [ passport, strategy ] = createPassport(spOptions);
   const hbs = configureHandlebars();
   const metricsMiddleware = promBundle({
@@ -43,6 +79,9 @@ export default function configureExpress(app, argv, idpOptions, spOptions, vetsA
   app.set('view engine', 'hbs');
   app.set('view options', { layout: 'layout' });
   app.engine('handlebars', hbs.__express);
+  app.use(Sentry.Handlers.requestHandler({
+    user: false,
+  }));
   app.use(metricsMiddleware);
   app.use(passport.initialize());
 
@@ -103,6 +142,7 @@ export default function configureExpress(app, argv, idpOptions, spOptions, vetsA
 
   addRoutes(app, idpOptions, spOptions);
 
+  app.use(Sentry.Handlers.errorHandler());
   // catch 404 and forward to error handler
   app.use(function(req, res, next) {
     const err = new Error('Route Not Found');

--- a/saml-proxy/src/routes/index.js
+++ b/saml-proxy/src/routes/index.js
@@ -26,7 +26,7 @@ function filterProperty(object, property) {
 }
 
 export default function configureExpress(app, argv, idpOptions, spOptions, vetsAPIOptions) {
-  const useSentry = typeof argv.sentryDSN !== 'undefined' && typeof argv.sentryEnvironment !== 'undefined';
+  const useSentry = argv.sentryDSN !== undefined && argv.sentryEnvironment !== undefined;
   if (useSentry) {
     Sentry.init({
       dsn: argv.sentryDSN,


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-contrib/issues/2838

Adds sentry reporting to oauth/saml proxies. Secrets are filtered out in `beforeSend`. I found the fields that need to be filtered by watching requests, let me know if you know of any more that need filtered. We could start logging all requests the proxies see in `dev` to look for more but that means we could be logging secrets in `dev`.

There is a bit of duplication between the saml and oauth proxies. Let me know if you can think of a good way of sharing some of the Sentry code across "projects".

~~Leaving as a draft until the Sentry projects get setup. I'm not a Sentry admin so I cannot create the projects myself.~~ I'm now a Sentry Admin (thanks Kalil) and have successfully created the Sentry projects.