### PR TITLE
Fix double render

### DIFF
--- a/saml-proxy/src/routes/acsHandlers.ts
+++ b/saml-proxy/src/routes/acsHandlers.ts
@@ -105,8 +105,9 @@ export const testLevelOfAssuranceOrRedirect = (req: IConfiguredRequest, res: Res
         authnContext: "http://idmanagement.gov/ns/assurance/loa/3"
       }
     }));
+  } else {
+    next();
   }
-  next();
 };
 
 export const serializeAssertions = (req: IConfiguredRequest, res: Response, next: NextFunction) => {


### PR DESCRIPTION
Redirects to `/samlproxy/sp/verify` cause a double render. The double render causes an error to hit [Sentry](http://sentry.vfs.va.gov/vets-gov/saml-proxy/issues/83609/?query=is%3Aunresolved). I don't think this will solve the Apple Health issue, there was no indication that anything was amiss when testing locally.