### PR TITLE
Use session secret from config

### DIFF
--- a/saml-proxy/src/cli/index.js
+++ b/saml-proxy/src/cli/index.js
@@ -137,6 +137,13 @@ export function processArgs() {
         required: false,
         string: true
       },
+      sessionSecret: {
+        description: 'Secret used to sign the session cookie',
+        // Required will need to be flipped to true once the saml-proxy is deployed
+        // with sessionSecret populated.
+        required: false,
+        string: true
+      },
       spProtocol: {
         description: 'Federation Protocol',
         required: true,

--- a/saml-proxy/src/cli/index.js
+++ b/saml-proxy/src/cli/index.js
@@ -139,9 +139,7 @@ export function processArgs() {
       },
       sessionSecret: {
         description: 'Secret used to sign the session cookie',
-        // Required will need to be flipped to true once the saml-proxy is deployed
-        // with sessionSecret populated.
-        required: false,
+        required: true,
         string: true
       },
       spProtocol: {

--- a/saml-proxy/src/routes/index.js
+++ b/saml-proxy/src/routes/index.js
@@ -27,9 +27,6 @@ function filterProperty(object, property) {
 
 export default function configureExpress(app, argv, idpOptions, spOptions, vetsAPIOptions) {
   const useSentry = argv.sentryDSN !== undefined && argv.sentryEnvironment !== undefined;
-  // The default secret is temporary while we move to having an actual secret for session signing. Having the secret
-  // default to the current hardcoded secret helps by allowing us to not worry about deployment schedules
-  const sessionSecret = argv.sessionSecret ? argv.sessionSecret : 'The universe works on a math equation that never even ever really ends in the end';
   if (useSentry) {
     Sentry.init({
       dsn: argv.sentryDSN,
@@ -108,7 +105,7 @@ export default function configureExpress(app, argv, idpOptions, spOptions, vetsA
   app.use(bodyParser.urlencoded({extended: true}));
   app.use(cookieParser());
   app.use(session({
-    secret: sessionSecret,
+    secret: argv.sessionSecret,
     resave: false,
     saveUninitialized: true,
     name: 'idp_sid',

--- a/saml-proxy/src/routes/index.js
+++ b/saml-proxy/src/routes/index.js
@@ -27,6 +27,9 @@ function filterProperty(object, property) {
 
 export default function configureExpress(app, argv, idpOptions, spOptions, vetsAPIOptions) {
   const useSentry = argv.sentryDSN !== undefined && argv.sentryEnvironment !== undefined;
+  // The default secret is temporary while we move to having an actual secret for session signing. Having the secret
+  // default to the current hardcoded secret helps by allowing us to not worry about deployment schedules
+  const sessionSecret = argv.sessionSecret ? argv.sessionSecret : 'The universe works on a math equation that never even ever really ends in the end';
   if (useSentry) {
     Sentry.init({
       dsn: argv.sentryDSN,
@@ -105,7 +108,7 @@ export default function configureExpress(app, argv, idpOptions, spOptions, vetsA
   app.use(bodyParser.urlencoded({extended: true}));
   app.use(cookieParser());
   app.use(session({
-    secret: 'The universe works on a math equation that never even ever really ends in the end',
+    secret: sessionSecret,
     resave: false,
     saveUninitialized: true,
     name: 'idp_sid',


### PR DESCRIPTION
This change makes the `saml-proxy` load the session secret from config. This PR will need to wait to be merged until the matching [devops PR](https://github.com/department-of-veterans-affairs/devops/pull/5942) is merged (so the secret is properly populated in the config when deployed).