### PR TITLE
Two updates to relay state logging

### DIFF
--- a/saml-proxy/src/routes/acsHandlers.ts
+++ b/saml-proxy/src/routes/acsHandlers.ts
@@ -113,28 +113,20 @@ export const testLevelOfAssuranceOrRedirect = (req: IConfiguredRequest, res: Res
 
 export const serializeAssertions = (req: IConfiguredRequest, res: Response, next: NextFunction) => {
   const authOptions = assignIn({}, req.idp.options);
-  const datetime = new Date().toISOString();
+  const time = new Date().toISOString();
   if (req.session) {
     authOptions.RelayState = req.session.ssoResponse.state;
     const logObj = {
       session: req.sessionID,
       stateFromSession: true,
       step: 'to Okta',
-      datetime,
+      time,
       relayState: authOptions.RelayState
     };
 
     logger.info(`Relay state to Okta (from session): ${authOptions.RelayState}`, logObj);
   } else {
     logRelayState(req, logger, 'to Okta');
-    const relayState = req.query.RelayState;
-    const logObj = {
-      session: req.sessionID,
-      step: 'to Okta',
-      datetime,
-      relayState
-    };
-    logger.info(`Relay state to Okta (query params): ${req.query.RelayState}`, logObj);
   }
   authOptions.authnContextClassRef = req.user.authnContext.authnMethod;
   samlp.auth(authOptions)(req, res, next);

--- a/saml-proxy/src/utils.js
+++ b/saml-proxy/src/utils.js
@@ -19,6 +19,16 @@ export function removeHeaders(cert) {
 };
 
 export function logRelayState(req, logger, step) {
-  const relayState = req.body.RelayState;
-  logger.info(`Relay state ${step}: ${relayState}`, { datetime: new Date().toISOString(), relayState, step: step, session: req.sessionID })
+  const relayStateBody = req.body.RelayState;
+  const relayStateQuery = req.query.RelayState;
+  logger.info(
+    `Relay state ${step} - body: ${relayStateBody} query: ${relayStateQuery}`,
+    {
+      time: new Date().toISOString(),
+      relayStateBody,
+      relayStateQuery,
+      step: step,
+      session: req.sessionID
+    }
+  );
 }


### PR DESCRIPTION
 1. datetime renamed to time to match other time fields
 2. log both body and query `RelayState`. Locally I only see relay state in the body but in `dev` I see it in the query params