### PR TITLE
Add metrics for user lookups

### DIFF
--- a/saml-proxy/src/metrics.ts
+++ b/saml-proxy/src/metrics.ts
@@ -1,0 +1,54 @@
+import client from 'prom-client';
+
+const defaultLabels = { app: 'saml_proxy' };
+client.register.setDefaultLabels(defaultLabels);
+const latencyBuckets = [0.1, 0.25, 0.5, 1, 2, 5, 10, 15];
+const bucketLabels = ['status_code'];
+
+export const MVILookupBucket = new client.Histogram({
+  name: 'mvi_lookup_bucket',
+  help: 'durtation histogram of duration of MVI lookup requests',
+  buckets: latencyBuckets,
+  labelNames: bucketLabels,
+});
+
+export const MVIAttempt = new client.Counter({
+  name: 'mvi_lookup_attempt',
+  help: 'counter of number of lookup requests sent to MVI',
+});
+
+export const MVIFailure = new client.Counter({
+  name: 'mvi_lookup_failure',
+  help: 'counter of number of lookup request failures from MVI',
+});
+
+export const VSOLookupBucket = new client.Histogram({
+  name: 'vso_lookup_bucket',
+  help: 'durtation histogram of duration of VSO lookup requests',
+  buckets: latencyBuckets,
+  labelNames: bucketLabels,
+});
+
+export const VSOAttempt = new client.Counter({
+  name: 'vso_lookup_attempt',
+  help: 'counter of number of lookup requests sent to VSO',
+});
+
+export const VSOFailure = new client.Counter({
+  name: 'vso_lookup_failure',
+  help: 'counter of number of lookup request failures from VSO',
+});
+
+export async function requestWithMetrics(histogram: client.Histogram, attempt: client.Counter, failure: client.Counter, promise: Promise<any>) {
+  const timer = histogram.startTimer();
+  attempt.inc();
+  try {
+    var res = await promise;
+    timer({status_code: '200'});
+    return res;
+  } catch(err) {
+    failure.inc();
+    timer({status_code: err.statusCode || 'unknown'});
+    throw err;
+  }
+}

--- a/saml-proxy/src/metrics.ts
+++ b/saml-proxy/src/metrics.ts
@@ -2,13 +2,16 @@ import client from 'prom-client';
 
 const defaultLabels = { app: 'saml_proxy' };
 client.register.setDefaultLabels(defaultLabels);
-const latencyBuckets = [0.1, 0.25, 0.5, 1, 2, 5, 10, 15];
+// Default buckets are [.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10]. There are too many buckets
+// on the low end and the max bucket is too high as well. Anything above 5 is too high. To help focus
+// the histogram on latencies we care about we only use a subset of the default
+const latencyBucketsSecs = [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5];
 const bucketLabels = ['status_code'];
 
 export const MVILookupBucket = new client.Histogram({
   name: 'mvi_lookup_requset_duration_seconds_bucket',
   help: 'durtation histogram of duration of MVI lookup requests labeled with: app, status_code',
-  buckets: latencyBuckets,
+  buckets: latencyBucketsSecs,
   labelNames: bucketLabels,
 });
 
@@ -25,7 +28,7 @@ export const MVIFailure = new client.Counter({
 export const VSOLookupBucket = new client.Histogram({
   name: 'vso_lookup_requset_duration_seconds_bucket',
   help: 'durtation histogram of duration of VSO lookup requests labeled with: app, status_code',
-  buckets: latencyBuckets,
+  buckets: latencyBucketsSecs,
   labelNames: bucketLabels,
 });
 
@@ -39,11 +42,11 @@ export const VSOFailure = new client.Counter({
   help: 'counter of number of lookup request failures from VSO',
 });
 
-export async function requestWithMetrics(histogram: client.Histogram, attempt: client.Counter, failure: client.Counter, promise: Promise<any>) {
+export async function requestWithMetrics(histogram: client.Histogram, attempt: client.Counter, failure: client.Counter, promiseFunc: () => Promise<any>) {
   const timer = histogram.startTimer();
   attempt.inc();
   try {
-    var res = await promise;
+    var res = await promiseFunc();
     timer({status_code: '200'});
     return res;
   } catch(err) {

--- a/saml-proxy/src/metrics.ts
+++ b/saml-proxy/src/metrics.ts
@@ -6,7 +6,7 @@ const latencyBuckets = [0.1, 0.25, 0.5, 1, 2, 5, 10, 15];
 const bucketLabels = ['status_code'];
 
 export const MVILookupBucket = new client.Histogram({
-  name: 'mvi_lookup_bucket',
+  name: 'mvi_lookup_requset_duration_seconds_bucket',
   help: 'durtation histogram of duration of MVI lookup requests labeled with: app, status_code',
   buckets: latencyBuckets,
   labelNames: bucketLabels,
@@ -23,7 +23,7 @@ export const MVIFailure = new client.Counter({
 });
 
 export const VSOLookupBucket = new client.Histogram({
-  name: 'vso_lookup_bucket',
+  name: 'vso_lookup_requset_duration_seconds_bucket',
   help: 'durtation histogram of duration of VSO lookup requests labeled with: app, status_code',
   buckets: latencyBuckets,
   labelNames: bucketLabels,

--- a/saml-proxy/src/metrics.ts
+++ b/saml-proxy/src/metrics.ts
@@ -9,8 +9,8 @@ const latencyBucketsSecs = [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5];
 const bucketLabels = ['status_code'];
 
 export const MVILookupBucket = new client.Histogram({
-  name: 'mvi_lookup_requset_duration_seconds_bucket',
-  help: 'durtation histogram of duration of MVI lookup requests labeled with: app, status_code',
+  name: 'mvi_lookup_request_duration_seconds_bucket',
+  help: 'histogram of duration of MVI lookup requests labeled with: app, status_code',
   buckets: latencyBucketsSecs,
   labelNames: bucketLabels,
 });
@@ -26,8 +26,8 @@ export const MVIFailure = new client.Counter({
 });
 
 export const VSOLookupBucket = new client.Histogram({
-  name: 'vso_lookup_requset_duration_seconds_bucket',
-  help: 'durtation histogram of duration of VSO lookup requests labeled with: app, status_code',
+  name: 'vso_lookup_request_duration_seconds_bucket',
+  help: 'histogram of duration of VSO lookup requests labeled with: app, status_code',
   buckets: latencyBucketsSecs,
   labelNames: bucketLabels,
 });

--- a/saml-proxy/src/metrics.ts
+++ b/saml-proxy/src/metrics.ts
@@ -8,50 +8,54 @@ client.register.setDefaultLabels(defaultLabels);
 const latencyBucketsSecs = [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5];
 const bucketLabels = ['status_code'];
 
-export const MVILookupBucket = new client.Histogram({
+const MVILookupBucket = new client.Histogram({
   name: 'mvi_lookup_request_duration_seconds_bucket',
   help: 'histogram of duration of MVI lookup requests labeled with: app, status_code',
   buckets: latencyBucketsSecs,
   labelNames: bucketLabels,
 });
 
-export const MVIAttempt = new client.Counter({
+const MVIAttempt = new client.Counter({
   name: 'mvi_lookup_attempt',
   help: 'counter of number of lookup requests sent to MVI',
 });
 
-export const MVIFailure = new client.Counter({
+const MVIFailure = new client.Counter({
   name: 'mvi_lookup_failure',
   help: 'counter of number of lookup request failures from MVI',
 });
 
-export const VSOLookupBucket = new client.Histogram({
+const VSOLookupBucket = new client.Histogram({
   name: 'vso_lookup_request_duration_seconds_bucket',
   help: 'histogram of duration of VSO lookup requests labeled with: app, status_code',
   buckets: latencyBucketsSecs,
   labelNames: bucketLabels,
 });
 
-export const VSOAttempt = new client.Counter({
+const VSOAttempt = new client.Counter({
   name: 'vso_lookup_attempt',
   help: 'counter of number of lookup requests sent to VSO',
 });
 
-export const VSOFailure = new client.Counter({
+const VSOFailure = new client.Counter({
   name: 'vso_lookup_failure',
   help: 'counter of number of lookup request failures from VSO',
 });
 
-export async function requestWithMetrics(histogram: client.Histogram, attempt: client.Counter, failure: client.Counter, promiseFunc: () => Promise<any>) {
-  const timer = histogram.startTimer();
-  attempt.inc();
-  try {
-    var res = await promiseFunc();
-    timer({status_code: '200'});
-    return res;
-  } catch(err) {
-    failure.inc();
-    timer({status_code: err.statusCode || 'unknown'});
-    throw err;
-  }
+export const MVIRequestMetrics = {
+  histogram: MVILookupBucket,
+  attempt: MVIAttempt,
+  failure: MVIFailure,
+}
+
+export const VSORequestMetrics = {
+  histogram: VSOLookupBucket,
+  attempt: VSOAttempt,
+  failure: MVIFailure,
+}
+
+export interface IRequestMetrics {
+  histogram: client.Histogram;
+  attempt: client.Counter;
+  failure: client.Counter;
 }

--- a/saml-proxy/src/metrics.ts
+++ b/saml-proxy/src/metrics.ts
@@ -7,7 +7,7 @@ const bucketLabels = ['status_code'];
 
 export const MVILookupBucket = new client.Histogram({
   name: 'mvi_lookup_bucket',
-  help: 'durtation histogram of duration of MVI lookup requests',
+  help: 'durtation histogram of duration of MVI lookup requests labeled with: app, status_code',
   buckets: latencyBuckets,
   labelNames: bucketLabels,
 });
@@ -24,7 +24,7 @@ export const MVIFailure = new client.Counter({
 
 export const VSOLookupBucket = new client.Histogram({
   name: 'vso_lookup_bucket',
-  help: 'durtation histogram of duration of VSO lookup requests',
+  help: 'durtation histogram of duration of VSO lookup requests labeled with: app, status_code',
   buckets: latencyBuckets,
   labelNames: bucketLabels,
 });

--- a/saml-proxy/src/routes/acsHandlers.test.ts
+++ b/saml-proxy/src/routes/acsHandlers.test.ts
@@ -3,6 +3,8 @@ import { Response, Request, NextFunction } from 'express';
 
 import * as handlers from './acsHandlers';
 import { VetsAPIClient } from '../VetsAPIClient';
+import { MVIRequestMetrics } from '../metrics';
+import { default as promclient } from 'prom-client';
 jest.mock('../VetsAPIClient');
 
 const client = new VetsAPIClient('fakeToken', 'https://example.gov');
@@ -196,5 +198,20 @@ describe('loadICN', () => {
     req.vetsAPIClient.getVSOSearch.mockRejectedValueOnce(err);
     await handlers.loadICN(req, { render }, nextFn);
     expect(render).toHaveBeenCalled();
+  });
+});
+
+describe('requestWithMetrics', () => {
+  it('should call the passed in functions promise', async () => {
+    let called = false;
+    const func = () => {
+      return new Promise((resolve, reject) => {
+        called = true;
+        resolve();
+      });
+    }
+
+    await handlers.requestWithMetrics(MVIRequestMetrics, func);
+    expect(called).toBeTruthy();
   });
 });

--- a/saml-proxy/src/routes/acsHandlers.ts
+++ b/saml-proxy/src/routes/acsHandlers.ts
@@ -6,6 +6,7 @@ import { NextFunction, Response } from "express";
 import assignIn from 'lodash.assignin';
 import samlp from "samlp"; import * as url from "url";
 import logger from './logger';
+import { MVILookupBucket, MVIAttempt, MVIFailure, VSOLookupBucket, VSOAttempt, VSOFailure, requestWithMetrics } from "../metrics";
 
 const unknownUsersErrorTemplate = (error: any) => {
   // `error` comes from:
@@ -60,7 +61,11 @@ export const loadICN = async (req: IConfiguredRequest, res: Response, next: Next
   const action = 'loadICN';
   
   try {
-    const { icn, first_name, last_name }= await req.vetsAPIClient.getMVITraitsForLoa3User(req.user.claims);
+    const {
+      icn,
+      first_name,
+      last_name
+    } = await requestWithMetrics(MVILookupBucket, MVIAttempt, MVIFailure, req.vetsAPIClient.getMVITraitsForLoa3User(req.user.claims));
     logger.info('Retrieved user traits from MVI', { session, action, result: 'success' });
     req.user.claims.icn = icn;
     req.user.claims.firstName = first_name;
@@ -71,7 +76,7 @@ export const loadICN = async (req: IConfiguredRequest, res: Response, next: Next
     logger.info(`Failed MVI lookup; will try VSO search: ${error}`, { session, action, result: 'failure' });
 
     try  {
-      await req.vetsAPIClient.getVSOSearch(req.user.claims.firstName, req.user.claims.lastName);
+      await requestWithMetrics(VSOLookupBucket, VSOAttempt, VSOFailure, req.vetsAPIClient.getVSOSearch(req.user.claims.firstName, req.user.claims.lastName));
       next();
     } catch (error) {
       logger.error(`Failed MVI lookup and VSO search: ${error}`, { session, action, result: 'failure' });


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-contrib/issues/2393

Add prometheus metrics for MVI and VSO lookups. Using different buckets than the default (.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10) but let me know if I should adjust from what I currently have.