### PR TITLE
Add prometheus counters to track oauth login flow

### DIFF
--- a/oauth-proxy/metrics.js
+++ b/oauth-proxy/metrics.js
@@ -1,0 +1,19 @@
+const client = require('prom-client');
+
+const defaultLabels = { app: 'oauth_proxy' };
+client.register.setDefaultLabels(defaultLabels);
+
+const loginBegin = new client.Counter({
+  name: 'oauth_login_begin',
+  help: 'counter of number of times the OAuth login process has begun',
+});
+
+const loginEnd = new client.Counter({
+  name: 'oauth_login_end',
+  help: 'counter of number of times the OAuth login process has ended',
+});
+
+module.exports = {
+  loginBegin,
+  loginEnd,
+}

--- a/oauth-proxy/metrics.js
+++ b/oauth-proxy/metrics.js
@@ -4,12 +4,12 @@ const defaultLabels = { app: 'oauth_proxy' };
 client.register.setDefaultLabels(defaultLabels);
 
 const loginBegin = new client.Counter({
-  name: 'oauth_login_begin',
+  name: 'oauth_proxy_login_begin',
   help: 'counter of number of times the OAuth login process has begun',
 });
 
 const loginEnd = new client.Counter({
-  name: 'oauth_login_end',
+  name: 'oauth_proxy_login_end',
   help: 'counter of number of times the OAuth login process has ended',
 });
 


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-contrib/issues/3697

This will add one counter to track number of users that have started the OAuth login process. It also will add a counter to track the number of users that have finished the OAuth login process. Together we should be able to get an idea about how many users are failing to complete the login process.