### PR TITLE
Configure node to trust va's internal certificate authority

### DIFF
--- a/oauth-proxy/Dockerfile
+++ b/oauth-proxy/Dockerfile
@@ -11,6 +11,8 @@ RUN npm install
 
 ADD ./certs/* /usr/local/share/ca-certificates/
 RUN update-ca-certificates
+RUN cat certs/*.pem > certs/combined.pem
+ENV NODE_EXTRA_CA_CERTS /opt/app/certs/combined.pem
 
 ADD ./ .
 

--- a/oauth-proxy/Dockerfile
+++ b/oauth-proxy/Dockerfile
@@ -11,10 +11,11 @@ RUN npm install
 
 ADD ./certs/* /usr/local/share/ca-certificates/
 RUN update-ca-certificates
-RUN cat certs/*.pem > certs/combined.pem
-ENV NODE_EXTRA_CA_CERTS /opt/app/certs/combined.pem
 
 ADD ./ .
+
+RUN cat certs/*.pem > certs/combined.pem
+ENV NODE_EXTRA_CA_CERTS /opt/app/certs/combined.pem
 
 EXPOSE 7100 7100
 HEALTHCHECK --interval=1m --timeout=4s \

--- a/saml-proxy/Dockerfile
+++ b/saml-proxy/Dockerfile
@@ -11,6 +11,8 @@ RUN npm install
 
 ADD ./certs/* /usr/local/share/ca-certificates/
 RUN update-ca-certificates
+RUN cat certs/*.pem > certs/combined.pem
+ENV NODE_EXTRA_CA_CERTS /opt/app/certs/combined.pem
 
 ADD ./ .
 

--- a/saml-proxy/Dockerfile
+++ b/saml-proxy/Dockerfile
@@ -11,10 +11,11 @@ RUN npm install
 
 ADD ./certs/* /usr/local/share/ca-certificates/
 RUN update-ca-certificates
-RUN cat certs/*.pem > certs/combined.pem
-ENV NODE_EXTRA_CA_CERTS /opt/app/certs/combined.pem
 
 ADD ./ .
+
+RUN cat certs/*.pem > certs/combined.pem
+ENV NODE_EXTRA_CA_CERTS /opt/app/certs/combined.pem
 
 EXPOSE 7000 7000
 


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-contrib/issues/3889

All outgoing traffic is intercepted and decrypted by the TIC, meaning our TLS connections are with the TIC, not the external site. Because of that, we need to trust the VA's internal certificate authority that signs the TIC's cert. Node doesn't use the system trust store, so we explicitly add the CA cert with an environment variable: https://nodejs.org/api/cli.html#cli_node_extra_ca_certs_file.