### PR TITLE
4xx errors are sent to sentry from oauth/saml proxies

### DIFF
--- a/saml-proxy/src/routes/index.js
+++ b/saml-proxy/src/routes/index.js
@@ -49,14 +49,6 @@ export default function configureExpress(app, argv, idpOptions, spOptions, vetsA
           event.request.data = data;
         }
         return event;
-      },
-      shouldHandleError(error) {
-        // This is the default for Sentry (above 500s are sent to Sentry). I think there is a discussion to be had on what
-        // errors we want to make it to Sentry. I could see us passing all errors through to Sentry, 4xx and 5xx
-        if (error.status >= 400) {
-          return true
-        }
-        return false
       }
     });
   }
@@ -152,15 +144,23 @@ export default function configureExpress(app, argv, idpOptions, spOptions, vetsA
 
   addRoutes(app, idpOptions, spOptions);
 
-  if (useSentry) {
-    app.use(Sentry.Handlers.errorHandler());
-  }
   // catch 404 and forward to error handler
   app.use(function(req, res, next) {
     const err = new Error('Route Not Found');
     err.status = 404;
     next(err);
   });
+
+  if (useSentry) {
+    app.use(Sentry.Handlers.errorHandler({
+      shouldHandleError(error) {
+        if (error.status >= 400) {
+          return true
+        }
+        return false
+      }
+    }));
+  }
 
   // development error handler
   app.use(function(err, req, res, next) {


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-contrib/issues/3906

`ShouldHandleError` was defined in the wrong place (see the [docs](https://docs.sentry.io/platforms/node/express/)). Some things to note:

 * The oauth proxy returns any error as a 500 error. This 500 wasn't caught by the Sentry error handler because it was set to 500 ***after*** the Sentry error handler is ran.
 * I removed an extra error handler that wasn't needed in the oauth proxy
 * I moved the Sentry error handler below the `404` middleware in the saml proxy. This ensures 404 errors reach Sentry