### PR TITLE
Extract larger route handlers into their own files.

### DIFF
--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -16,7 +16,7 @@ const promBundle = require('express-prom-bundle');
 const Sentry = require('@sentry/node');
 const { logger, middlewareLogFormat } = require('./logger');
 
-const { loginBegin, loginEnd } = require('./metrics');
+const oauthHandlers = require('./oauthHandlers');
 
 const appRoutes = {
   authorize: '/authorization',
@@ -162,159 +162,15 @@ function buildApp(config, issuer, oktaClient, dynamo, dynamoClient) {
   });
 
   router.get(appRoutes.redirect, async (req, res, next) => {
-    const { state } = req.query;
-    if (!req.query.hasOwnProperty('error')) {
-      try {
-        await dynamoClient.saveToDynamo(dynamo, state, "code", req.query.code);
-      } catch (error) {
-        logger.error(`Failed to save authorization code in ${appRoutes.redirect} handler`, error);
-      }
-    }
-    try {
-      const document = await dynamoClient.getFromDynamoByState(dynamo, state);
-      const params = new URLSearchParams(req.query);
-      loginEnd.inc();
-      res.redirect(`${document.redirect_uri.S}?${params.toString()}`)
-    } catch (error) {
-      logger.error("Failed to redirect to the OAuth client application", error);
-      return next(error); // This error is unrecoverable because we can't look up the original redirect.
-    }
+    await oauthHandlers.redirectHandler(logger, dynamo, dynamoClient, req, res, next);
   });
 
   router.get(appRoutes.authorize, async (req, res, next) => {
-    loginBegin.inc();
-    const { state, client_id, redirect_uri: client_redirect } = req.query;
-    try {
-      const oktaApp = await oktaClient.getApplication(client_id);
-      if (oktaApp.settings.oauthClient.redirect_uris.indexOf(client_redirect) === -1) {
-        const errorParams = new URLSearchParams({
-          error: 'invalid_client',
-          error_description: 'The redirect URI specified by the application does not match any of the ' +
-                             `registered redirect URIs. Erroneous redirect URI: ${client_redirect}`
-        });
-        return res.redirect(`${client_redirect}?${errorParams.toString()}`);
-      }
-    } catch (error) {
-      logger.error("Unrecoverable error: could not get the Okta client app", error);
-      // This error is unrecoverable because we would be unable to verify
-      // that we are redirecting to a whitelisted client url
-      return next(error);
-    }
-
-    try {
-      await dynamoClient.saveToDynamo(dynamo, state, "redirect_uri", client_redirect);
-    } catch (error) {
-      logger.error(`Failed to save client redirect URI ${client_redirect} in ${appRoutes.authorize} handler`, error);
-      return next(error); // This error is unrecoverable because we can't create a record to lookup the requested redirect
-    }
-    const params = new URLSearchParams(req.query);
-    params.set('redirect_uri', redirect_uri);
-    if (!params.has('idp') && config.idp) {
-      params.set('idp', config.idp);
-    }
-    res.redirect(`${issuer.metadata.authorization_endpoint}?${params.toString()}`)
+    await oauthHandlers.authorizeHandler(config, redirect_uri, logger, issuer, dynamo, dynamoClient, oktaClient, req, res, next)
   });
 
   router.post(appRoutes.token, async (req, res, next) => {
-    let client_id, client_secret;
-
-    if (req.headers.authorization) {
-      const authHeader = req.headers.authorization.match(/^Basic\s(.*)$/);
-      ([ client_id, client_secret ] = Buffer.from(authHeader[1], 'base64').toString('utf-8').split(':'));
-    } else if (req.body.client_id && req.body.client_secret) {
-      ({ client_id, client_secret } = req.body);
-      delete req.body.client_id;
-      delete req.body.client_secret;
-    } else {
-      return res.status(401).json({
-        error: "invalid_client",
-        error_description: "Client authentication failed",
-      });
-    }
-
-    const client = new issuer.Client({
-      client_id,
-      client_secret,
-      redirect_uris: [
-        redirect_uri
-      ],
-    });
-
-    let tokens, state;
-    if (req.body.grant_type === 'refresh_token') {
-      try {
-        tokens = await client.refresh(req.body.refresh_token);
-      } catch (error) {
-        logger.error("Could not refresh the client session with the provided refresh token", error);
-        const statusCode = statusCodeFromError(error);
-        res.status(statusCode).json({
-          error: error.error,
-          error_description: error.error_description,
-        });
-      }
-      try {
-        const document = await dynamoClient.getFromDynamoBySecondary(dynamo, 'refresh_token', req.body.refresh_token);
-        state = document.state.S;
-        await dynamoClient.saveToDynamo(dynamo, state, 'refresh_token', tokens.refresh_token);
-      } catch (error) {
-        logger.error("Could not update the refresh token in DynamoDB", error);
-        state = null;
-      }
-    } else if (req.body.grant_type === 'authorization_code') {
-      try {
-        tokens = await client.grant(
-          {...req.body, redirect_uri }
-        );
-      } catch (error) {
-        logger.error("Failed to retrieve tokens using the OpenID client", error);
-        const statusCode = statusCodeFromError(error);
-        res.status(statusCode).json({
-          error: error.error,
-          error_description: error.error_description,
-        });
-      }
-      try {
-        const document = await dynamoClient.getFromDynamoBySecondary(dynamo, 'code', req.body.code);
-        state = document.state.S;
-        if (tokens.refresh_token) {
-          await dynamoClient.saveToDynamo(dynamo, state, 'refresh_token', tokens.refresh_token);
-        }
-      } catch (error) {
-        logger.error("Failed to save the new refresh token to DynamoDB", error);
-        state = null;
-      }
-    } else {
-      return res.status(400).json({
-        error: "unsupported_grant_type",
-        error_description: "Only authorization and refresh_token grant types are supported",
-      });
-    }
-
-    var decoded = jwtDecode(tokens.access_token);
-    if ((decoded.scp != null) && (decoded.scp.indexOf('launch/patient') > -1)) {
-      try {
-        const response = await requestPromise({
-          method: 'GET',
-          uri: config.validate_endpoint,
-          json: true,
-          headers: {
-            apiKey: config.validate_apiKey,
-            authorization: `Bearer ${tokens.access_token}`,
-          }
-        });
-        const patient = response.data.attributes.va_identifiers.icn;
-        res.json({...tokens, patient, state});
-      } catch (err) {
-        logger.error("Could not find a valid patient identifier for the provided authorization code", err);
-
-        res.status(400).json({
-          error: "invalid_grant",
-          error_description: "We were unable to find a valid patient identifier for the provided authorization code.",
-        });
-      }
-    } else {
-      res.json({...tokens, state});
-    }
+    await oauthHandlers.tokenHandler(config, redirect_uri, logger, issuer, dynamo, dynamoClient, req, res, next)
   });
 
   app.use(well_known_base_path, router)

--- a/oauth-proxy/oauthHandlers/authorizeHandler.js
+++ b/oauth-proxy/oauthHandlers/authorizeHandler.js
@@ -1,0 +1,38 @@
+const { URLSearchParams } = require('url');
+const { loginBegin } = require('../metrics');
+
+const authorizeHandler = async (config, redirect_uri, logger, issuer, dynamo, dynamoClient, oktaClient, req, res, next) => {
+  loginBegin.inc();
+  const { state, client_id, redirect_uri: client_redirect } = req.query;
+  try {
+    const oktaApp = await oktaClient.getApplication(client_id);
+    if (oktaApp.settings.oauthClient.redirect_uris.indexOf(client_redirect) === -1) {
+      const errorParams = new URLSearchParams({
+        error: 'invalid_client',
+        error_description: 'The redirect URI specified by the application does not match any of the ' +
+        `registered redirect URIs. Erroneous redirect URI: ${client_redirect}`
+      });
+      return res.redirect(`${client_redirect}?${errorParams.toString()}`);
+    }
+  } catch (error) {
+    logger.error("Unrecoverable error: could not get the Okta client app", error);
+    // This error is unrecoverable because we would be unable to verify
+    // that we are redirecting to a whitelisted client url
+    return next(error);
+  }
+
+  try {
+    await dynamoClient.saveToDynamo(dynamo, state, "redirect_uri", client_redirect);
+  } catch (error) {
+    logger.error(`Failed to save client redirect URI ${client_redirect} in authorize handler`);
+    return next(error); // This error is unrecoverable because we can't create a record to lookup the requested redirect
+  }
+  const params = new URLSearchParams(req.query);
+  params.set('redirect_uri', redirect_uri);
+  if (!params.has('idp') && config.idp) {
+    params.set('idp', config.idp);
+  }
+  res.redirect(`${issuer.metadata.authorization_endpoint}?${params.toString()}`)
+};
+
+module.exports = authorizeHandler;

--- a/oauth-proxy/oauthHandlers/index.js
+++ b/oauth-proxy/oauthHandlers/index.js
@@ -1,0 +1,7 @@
+// This module should eventually contain an express route handler for each
+// official OAuth 2.0 endpoint.
+module.exports = {
+  'authorizeHandler': require('./authorizeHandler'),
+  'tokenHandler': require('./tokenHandler'),
+  'redirectHandler': require('./redirectHandler'),
+};

--- a/oauth-proxy/oauthHandlers/redirectHandler.js
+++ b/oauth-proxy/oauthHandlers/redirectHandler.js
@@ -1,0 +1,24 @@
+const { URLSearchParams } = require('url');
+const { loginEnd } = require('../metrics');
+
+const redirectHandler = async (logger, dynamo, dynamoClient, req, res, next) => {
+  const { state } = req.query;
+  if (!req.query.hasOwnProperty('error')) {
+    try {
+      await dynamoClient.saveToDynamo(dynamo, state, "code", req.query.code);
+    } catch (error) {
+      logger.error(`Failed to save authorization code in redirect handler`, error);
+    }
+  }
+  try {
+    const document = await dynamoClient.getFromDynamoByState(dynamo, state);
+    const params = new URLSearchParams(req.query);
+    loginEnd.inc();
+    res.redirect(`${document.redirect_uri.S}?${params.toString()}`)
+  } catch (error) {
+    logger.error("Failed to redirect to the OAuth client application", error);
+    return next(error); // This error is unrecoverable because we can't look up the original redirect.
+  }
+};
+
+module.exports = redirectHandler;

--- a/oauth-proxy/oauthHandlers/tokenHandler.js
+++ b/oauth-proxy/oauthHandlers/tokenHandler.js
@@ -1,4 +1,5 @@
 const jwtDecode = require('jwt-decode');
+const requestPromise = require('request-promise-native');
 
 const tokenHandler = async (config, redirect_uri, logger, issuer, dynamo, dynamoClient, req, res, next) => {
   let client_id, client_secret;

--- a/oauth-proxy/oauthHandlers/tokenHandler.js
+++ b/oauth-proxy/oauthHandlers/tokenHandler.js
@@ -1,0 +1,105 @@
+const jwtDecode = require('jwt-decode');
+
+const tokenHandler = async (config, redirect_uri, logger, issuer, dynamo, dynamoClient, req, res, next) => {
+  let client_id, client_secret;
+
+  if (req.headers.authorization) {
+    const authHeader = req.headers.authorization.match(/^Basic\s(.*)$/);
+    ([ client_id, client_secret ] = Buffer.from(authHeader[1], 'base64').toString('utf-8').split(':'));
+  } else if (req.body.client_id && req.body.client_secret) {
+    ({ client_id, client_secret } = req.body);
+    delete req.body.client_id;
+    delete req.body.client_secret;
+  } else {
+    return res.status(401).json({
+      error: "invalid_client",
+      error_description: "Client authentication failed",
+    });
+  }
+
+  const client = new issuer.Client({
+    client_id,
+    client_secret,
+    redirect_uris: [
+      redirect_uri
+    ],
+  });
+
+  let tokens, state;
+  if (req.body.grant_type === 'refresh_token') {
+    try {
+      tokens = await client.refresh(req.body.refresh_token);
+    } catch (error) {
+      logger.error("Could not refresh the client session with the provided refresh token", error);
+      const statusCode = statusCodeFromError(error);
+      res.status(statusCode).json({
+        error: error.error,
+        error_description: error.error_description,
+      });
+    }
+    try {
+      const document = await dynamoClient.getFromDynamoBySecondary(dynamo, 'refresh_token', req.body.refresh_token);
+      state = document.state.S;
+      await dynamoClient.saveToDynamo(dynamo, state, 'refresh_token', tokens.refresh_token);
+    } catch (error) {
+      logger.error("Could not update the refresh token in DynamoDB", error);
+      state = null;
+    }
+  } else if (req.body.grant_type === 'authorization_code') {
+    try {
+      tokens = await client.grant(
+        {...req.body, redirect_uri }
+      );
+    } catch (error) {
+      logger.error("Failed to retrieve tokens using the OpenID client", error);
+      const statusCode = statusCodeFromError(error);
+      res.status(statusCode).json({
+        error: error.error,
+        error_description: error.error_description,
+      });
+    }
+    try {
+      const document = await dynamoClient.getFromDynamoBySecondary(dynamo, 'code', req.body.code);
+      state = document.state.S;
+      if (tokens.refresh_token) {
+        await dynamoClient.saveToDynamo(dynamo, state, 'refresh_token', tokens.refresh_token);
+      }
+    } catch (error) {
+      logger.error("Failed to save the new refresh token to DynamoDB", error);
+      state = null;
+    }
+  } else {
+    return res.status(400).json({
+      error: "unsupported_grant_type",
+      error_description: "Only authorization and refresh_token grant types are supported",
+    });
+  }
+
+  var decoded = jwtDecode(tokens.access_token);
+  if ((decoded.scp != null) && (decoded.scp.indexOf('launch/patient') > -1)) {
+    try {
+      const response = await requestPromise({
+        method: 'GET',
+        uri: config.validate_endpoint,
+        json: true,
+        headers: {
+          apiKey: config.validate_apiKey,
+          authorization: `Bearer ${tokens.access_token}`,
+        }
+      });
+      const patient = response.data.attributes.va_identifiers.icn;
+      res.json({...tokens, patient, state});
+    } catch (err) {
+      logger.error("Could not find a valid patient identifier for the provided authorization code", err);
+
+      res.status(400).json({
+        error: "invalid_grant",
+        error_description: "We were unable to find a valid patient identifier for the provided authorization code.",
+      });
+    }
+  } else {
+    res.json({...tokens, state});
+  }
+};
+
+module.exports = tokenHandler;

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -122,7 +122,7 @@ describe('OpenID Connect Conformance', () => {
     });
     dynamoClient = buildFakeDynamoClient({
       state: 'abc123',
-      code: 'xzy789',
+      code: 'xyz789',
       refresh_token: 'jkl456',
       redirect_uri: FAKE_CLIENT_APP_REDIRECT_URL,
     });
@@ -266,7 +266,7 @@ describe('OpenID Connect Conformance', () => {
       },
       form: {
         grant_type: 'authorization_code',
-        code: 'xyz123',
+        code: 'xyz789',
       }
     });
 

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -27,6 +27,11 @@ const defaultTestingConfig = {
   upstream_issuer: upstreamOAuthTestServer.baseUrl(),
 };
 
+function encodeAuthHeader(username, password) {
+  const encodedCredentials = Buffer.from(`${username}:${password}`).toString('base64');
+  return `Basic ${encodedCredentials}`;
+}
+
 function buildFakeOktaClient(fakeRecord) {
   const oktaClient = { getApplication: jest.fn() };
   oktaClient.getApplication.mockImplementation(client_id => {
@@ -247,5 +252,34 @@ describe('OpenID Connect Conformance', () => {
     });
     expect(resp.statusCode).toEqual(302);
     expect(resp.headers.location).toMatch(new RegExp(`^${FAKE_CLIENT_APP_REDIRECT_URL}.*$`));
+  });
+
+  it('returns an OIDC conformant token response', async () => {
+    const resp = await request({
+      simple: false,
+      resolveWithFullResponse: true,
+      method: 'post',
+      uri: 'http://localhost:9090/testServer/token',
+      headers: {
+        'authorization': encodeAuthHeader('user', 'pass'),
+        'origin': 'http://localhost:8080',
+      },
+      form: {
+        grant_type: 'authorization_code',
+        code: 'xyz123',
+      }
+    });
+
+    expect(resp.statusCode).toEqual(200);
+    const parsedResp = JSON.parse(resp.body);
+    const JWT_PATTERN = /[-_a-zA-Z0-9]+[.][-_a-zA-Z0-9]+[.][-_a-zA-Z0-9]+/;
+    expect(parsedResp).toMatchObject({
+      access_token: expect.stringMatching(JWT_PATTERN),
+      expires_at: expect.any(Number),
+      id_token: expect.stringMatching(JWT_PATTERN),
+      refresh_token: expect.stringMatching(/[-_a-zA-Z0-9]+/),
+      scope: expect.stringMatching(/.+/),
+      token_type: 'Bearer',
+    });
   });
 });


### PR DESCRIPTION
This should be a 1:1 extraction from index.js for each of these handlers. At this point the function signatures look pretty painful. That reflects just how much of the index.js lexical scope these functions were capturing. With these defines in isolation we can begin testing them as units rather than fully integrated as an express app. This should alleviate the painful function signatures over time, as we find ways to break these down.