### PR TITLE
Use expires_in instead of expires_at

### DIFF
--- a/oauth-proxy/oauthHandlers/tokenResponse.js
+++ b/oauth-proxy/oauthHandlers/tokenResponse.js
@@ -1,0 +1,65 @@
+// Returns an object suitable for the response body of an OAuth 2.0 token
+// response. The input is a TokenSet object from the openid-client library. See
+// documentation here:
+// https://github.com/panva/node-openid-client/blob/master/docs/README.md#tokenset
+//
+// The returned object will always have these keys:
+//   * access_token
+//   * expires_in
+//   * refresh_token
+//   * scope
+// If the token set is for an OIDC request it will also have:
+//   * id_token
+const translateTokenSet = (token_set) => {
+  // Example successful response from RFC 6749
+  // {
+  //   "access_token":"2YotnFZFEjr1zCsicMWpAA",
+  //   "token_type":"example",
+  //   "expires_in":3600,
+  //   "refresh_token":"tGzv3JOkF0XG5Qx2TlKWIA",
+  //   "example_parameter":"example_value"
+  // }
+
+  // Example successful response from OpenID Connect Core 1.0
+  // {
+  //  "access_token": "SlAV32hkKG",
+  //  "token_type": "Bearer",
+  //  "refresh_token": "8xLOxBtZp8",
+  //  "expires_in": 3600,
+  //  "id_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IjFlOWdkazcifQ.ewogImlzc
+  //    yI6ICJodHRwOi8vc2VydmVyLmV4YW1wbGUuY29tIiwKICJzdWIiOiAiMjQ4Mjg5
+  //    NzYxMDAxIiwKICJhdWQiOiAiczZCaGRSa3F0MyIsCiAibm9uY2UiOiAibi0wUzZ
+  //    fV3pBMk1qIiwKICJleHAiOiAxMzExMjgxOTcwLAogImlhdCI6IDEzMTEyODA5Nz
+  //    AKfQ.ggW8hZ1EuVLuxNuuIJKX_V8a_OMXzR0EHR9R6jgdqrOOF4daGU96Sr_P6q
+  //    Jp6IcmD3HP99Obi1PRs-cwh3LO-p146waJ8IhehcwL7F09JdijmBqkvPeB2T9CJ
+  //    NqeGpe-gccMg4vfKjkM8FcGvnzZUN4_KSP0aAp1tOJ1zZwgjxqGByKHiOtX7Tpd
+  //    QyHE5lcMiKPXfEIQILVq0pc_E2DzL7emopWoaoZTF_m0_N0YzFC6g6EJbOEoRoS
+  //    K5hoDalrcvRYLSrQAZZKflyuVCyixEoV9GfNQC3_osjzw2PAithfubEEBLuVVk4
+  //    XUVrWOLrLl0nx7RkKU8NXNHq-rvKMzqg"
+  // }
+
+  const responseAccum = {};
+  const copy_field = (field) => {
+    if (token_set[field] != null) {
+      responseAccum[field] = token_set[field];
+    }
+  };
+
+  // We need to copy these fields individually in order to control the shape of
+  // the returned object. The `TokenSet.expires_in` field is a property, which
+  // translates from an absolute timestamp field named `expires_at`. If we
+  // simply serialized the `TokenSet` object then the response would contain
+  // the internal fields liked `expires_at`.
+  copy_field('access_token');
+  copy_field('id_token');
+  copy_field('refresh_token');
+  copy_field('token_type');
+  copy_field('scope');
+  copy_field('expires_in');
+
+  return responseAccum;
+};
+
+module.exports = {
+  translateTokenSet: translateTokenSet
+};

--- a/oauth-proxy/package-lock.json
+++ b/oauth-proxy/package-lock.json
@@ -5780,6 +5780,12 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
+    "timekeeper": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/timekeeper/-/timekeeper-2.2.0.tgz",
+      "integrity": "sha512-W3AmPTJWZkRwu+iSNxPIsLZ2ByADsOLbbLxe46UJyWj3mlYLlwucKiq+/dPm0l9wTzqoF3/2PH0AGFCebjq23A==",
+      "dev": true
+    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",

--- a/oauth-proxy/package.json
+++ b/oauth-proxy/package.json
@@ -37,7 +37,8 @@
     "yargs": "^12.0.5"
   },
   "devDependencies": {
+    "crypto": "^1.0.1",
     "jest": "^24.8.0",
-    "crypto": "^1.0.1"
+    "timekeeper": "^2.2.0"
   }
 }

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -130,7 +130,7 @@ describe('OpenID Connect Conformance', () => {
     });
     dynamoHandle = jest.mock();
 
-    const tokenValidator = (access_token) => {
+    const fakeTokenValidator = (access_token) => {
       return {
         va_identifiers: {
           icn: '0000000000000'
@@ -138,7 +138,7 @@ describe('OpenID Connect Conformance', () => {
       };
     };
 
-    const app = buildApp(defaultTestingConfig, issuer, oktaClient, dynamoHandle, dynamoClient, tokenValidator);
+    const app = buildApp(defaultTestingConfig, issuer, oktaClient, dynamoHandle, dynamoClient, fakeTokenValidator);
     // We're starting and stopping this server in a beforeAll/afterAll pair,
     // rather than beforeEach/afterEach because this is an end-to-end
     // functional. Since internal application state could affect functionality
@@ -285,7 +285,7 @@ describe('OpenID Connect Conformance', () => {
     const JWT_PATTERN = /[-_a-zA-Z0-9]+[.][-_a-zA-Z0-9]+[.][-_a-zA-Z0-9]+/;
     expect(parsedResp).toMatchObject({
       access_token: expect.stringMatching(JWT_PATTERN),
-      expires_at: expect.any(Number),
+      expires_in: expect.any(Number),
       id_token: expect.stringMatching(JWT_PATTERN),
       refresh_token: expect.stringMatching(/[-_a-zA-Z0-9]+/),
       scope: expect.stringMatching(/.+/),

--- a/oauth-proxy/tests/oauthHandlers.test.js
+++ b/oauth-proxy/tests/oauthHandlers.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+require('jest');
+
+const { TokenSet } = require('openid-client');
+const { translateTokenSet } = require('../oauthHandlers/tokenResponse');
+
+describe('translateTokenSet', () => {
+  it('omits id_token if not in TokenSet', async () => {
+    const oauth_only_set = new TokenSet({
+      access_token: 'oauth.is.cool',
+      refresh_token: 'refresh.later',
+      expires_in: 3600,
+    });
+    const translated = translateTokenSet(oauth_only_set);
+    expect(translated).not.toHaveProperty('id_token');
+  });
+
+  it('copies id_token for OIDC', async () => {
+    const fake_id_token = 'oidc.is.cool';
+    const oidc_set = new TokenSet({
+      access_token: 'oauth.is.cool',
+      refresh_token: 'refresh.later',
+      id_token: fake_id_token,
+      expires_in: 3600,
+    });
+
+    const translated = translateTokenSet(oidc_set);
+    expect(translated).toHaveProperty('id_token');
+    expect(translated.id_token).toEqual(fake_id_token);
+  });
+
+  it('translates absolute timestamps to relative timestamps', async () => {
+    const abs_oauth_set = new TokenSet({
+      access_token: 'oauth.is.cool',
+      refresh_token: 'refresh.later',
+      expires_in: 7200,
+    });
+    const now_sec = Math.floor(Date.now() / 1000);
+    expect(abs_oauth_set.expires_at - now_sec).toBeGreaterThanOrEqual(7200);
+    expect(abs_oauth_set.expires_at - now_sec).toBeLessThan(7201);
+
+    const translated = translateTokenSet(abs_oauth_set);
+    expect(translated).toHaveProperty('expires_in');
+    expect(translated.expires_in).toEqual(7200);
+  });
+});
+


### PR DESCRIPTION
When the proxy requests the grant from the upstream oauth server it receives a `TokenSet` object ([docs here](https://github.com/panva/node-openid-client/blob/master/docs/README.md#tokenset)). The library translates the `expires_in` field from the upstream server to an `expires_at` field, translating from a relative timestamp to an absolute timestamp. The proxy was serializing this object directly, causing the client application to see a non-conformant token response that lacked an `expires_in` field. This PR fixes that by making the proxy fully responsible for the shape of the response to the client application.