### PR TITLE
Don't run tests as root in container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
     stage('Run saml-proxy tests') {
       agent {
         dockerfile {
-          args "--entrypoint='' -u 0:0"
+          args "--entrypoint=''"
           dir "saml-proxy"
           label 'vetsgov-general-purpose'
         }
@@ -34,7 +34,7 @@ pipeline {
     stage('Run oauth-proxy tests') {
       agent {
         dockerfile {
-          args "--entrypoint='' -u 0:0"
+          args "--entrypoint=''"
           dir "oauth-proxy"
           label 'vetsgov-general-purpose'
         }


### PR DESCRIPTION
Several recent runs of the testing job have failed on master when jenkins is unable to delete the node_modules directory because it's owned by root.

We've only seen the issue on master, so it's hard to say for sure if this will fix it or not.