### PR TITLE
Make tokenHandler call next() in all paths.

### DIFF
--- a/oauth-proxy/package-lock.json
+++ b/oauth-proxy/package-lock.json
@@ -4352,6 +4352,56 @@
         }
       }
     },
+    "mock-express-request": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/mock-express-request/-/mock-express-request-0.2.2.tgz",
+      "integrity": "sha512-EymHjY1k1jWIsaVaCsPdFterWO18gcNwQMb99OryhSBtIA33SZJujOLeOe03Rf2DTV997xLPyl2I098WCFm/mA==",
+      "dev": true,
+      "requires": {
+        "accepts": "^1.3.4",
+        "fresh": "^0.5.2",
+        "lodash": "^4.17.4",
+        "mock-req": "^0.2.0",
+        "parseurl": "^1.3.2",
+        "range-parser": "^1.2.0",
+        "type-is": "^1.6.15"
+      }
+    },
+    "mock-express-response": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/mock-express-response/-/mock-express-response-0.2.2.tgz",
+      "integrity": "sha512-+pRUv25LhyKZVSRCOzoZp8TW0nqvT7UlH7vpVzCibjjEucXL72gTgwEhmqbyTO2LI9IlyIeBBdflR9Ml5KQWMQ==",
+      "dev": true,
+      "requires": {
+        "content-disposition": "^0.5.2",
+        "content-type": "^1.0.4",
+        "cookie": "^0.3.1",
+        "cookie-signature": "^1.0.6",
+        "depd": "^1.1.1",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "mock-express-request": "^0.2.2",
+        "mock-res": "^0.5.0",
+        "on-finished": "^2.3.0",
+        "proxy-addr": "^2.0.2",
+        "qs": "^6.5.1",
+        "send": "^0.16.1",
+        "utils-merge": "^1.0.1",
+        "vary": "^1.1.2"
+      }
+    },
+    "mock-req": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/mock-req/-/mock-req-0.2.0.tgz",
+      "integrity": "sha1-dJRGgE0sAGFpNC7nvmu6HP/VNMI=",
+      "dev": true
+    },
+    "mock-res": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mock-res/-/mock-res-0.5.0.tgz",
+      "integrity": "sha1-mDaL6wnfdT9k9m2U5VNql7NqJDA=",
+      "dev": true
+    },
     "morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",

--- a/oauth-proxy/package.json
+++ b/oauth-proxy/package.json
@@ -39,6 +39,8 @@
   "devDependencies": {
     "crypto": "^1.0.1",
     "jest": "^24.8.0",
-    "timekeeper": "^2.2.0"
+    "timekeeper": "^2.2.0",
+    "mock-express-request": "^0.2.2",
+    "mock-express-response": "^0.2.2"
   }
 }

--- a/oauth-proxy/tests/oauthHandlers.test.js
+++ b/oauth-proxy/tests/oauthHandlers.test.js
@@ -2,10 +2,16 @@
 
 require('jest');
 
-const { TokenSet } = require('openid-client');
+const MockExpressRequest = require('mock-express-request');
+const MockExpressResponse = require('mock-express-response');
+const { Client, Issuer, TokenSet } = require('openid-client');
+const { RequestError } = require('request-promise-native/errors');
 const timekeeper = require('timekeeper');
 
+const { tokenHandler } = require('../oauthHandlers');
 const { translateTokenSet } = require('../oauthHandlers/tokenResponse');
+const { encodeBasicAuthHeader } = require('../utils');
+const { convertObjectToDynamoAttributeValues } = require('./testUtils');
 
 describe('translateTokenSet', () => {
   it('omits id_token if not in TokenSet', async () => {
@@ -49,6 +55,216 @@ describe('translateTokenSet', () => {
     } finally {
       timekeeper.reset();
     }
+  });
+});
+
+function buildFakeDynamoClient(fakeDynamoRecord) {
+  const dynamoClient = jest.genMockFromModule('../dynamo_client.js');
+  dynamoClient.saveToDynamo.mockImplementation((handle, state, key, value) => {
+    return new Promise((resolve, reject) => {
+      // It's unclear whether this should resolve with a full records or just
+      // the identity field but thus far it has been irrelevant to the
+      // functional testing of the oauth-proxy.
+      resolve({ pk: state });
+    });
+  });
+  dynamoClient.getFromDynamoBySecondary.mockImplementation((handle, attr, value) => {
+    return new Promise((resolve, reject) => {
+      if (fakeDynamoRecord[attr] === value) {
+        resolve(convertObjectToDynamoAttributeValues(fakeDynamoRecord));
+      } else {
+        reject(`no such ${attr} value`);
+      }
+    });
+  });
+  dynamoClient.getFromDynamoByState.mockImplementation((handle, state) => {
+    return new Promise((resolve, reject) => {
+      if (state === fakeDynamoRecord.state) {
+        resolve(convertObjectToDynamoAttributeValues(fakeDynamoRecord));
+      } else {
+        reject('no such state value');
+      }
+    });
+  });
+  return dynamoClient;
+}
+
+class FakeIssuer {
+  constructor(client) {
+    this.Client = class FakeInlineClient {
+      constructor(_) {
+        return client;
+      }
+    };
+  }
+}
+
+describe('tokenHandler', () => {
+  let config;
+  let redirect_uri;
+  let issuer;
+  let logger;
+  let dynamo;
+  let dynamoClient;
+  let validateToken;
+  let next;
+
+  beforeEach(() => {
+    config = jest.mock();
+    redirect_uri = jest.mock();
+    issuer = jest.mock();
+    logger = { error: jest.fn(), info: jest.fn() };
+    dynamo = jest.mock();
+    dynamoClient = jest.mock();
+    validateToken = jest.fn();
+    next = jest.fn();
+  });
+
+  afterEach(() => {
+    // expressjs requires that all handlers call next() unless they want to
+    // stop the remaining middleware from running. Since the remaining
+    // middleware is defined by the application, this should not be done by the
+    // tokenHandler at all.
+    expect(next).toHaveBeenCalled();
+  });
+
+  let buildOpenIDClient = (fns) => {
+    let client = {};
+    for (let [fn_name, fn_impl] of Object.entries(fns)) {
+      client[fn_name] = jest.fn().mockImplementation(async (_) => {
+        return new Promise((resolve, reject) => {
+          fn_impl(resolve, reject);
+        });
+      });
+    }
+    return client;
+  };
+
+  let buildExpiredRefreshTokenClient = () => {
+    return buildOpenIDClient({
+      refresh: (_resolve, _reject) => {
+        // This simulates an upstream error so that we don't have to test the full handler.
+        throw new RequestError(
+          new Error("simulated upstream response error for expired refresh token"),
+          {},
+          { statusCode: 400 },
+        );
+      }
+    });
+  };
+
+  it('handles the authorization_code flow', async () => {
+    let req = new MockExpressRequest({
+      body: {
+        'grant_type': 'authorization_code',
+        'code': 'the_fake_authorization_code',
+        'client_id': 'client123',
+        'client_secret': 'secret789',
+      }
+    });
+    dynamoClient = buildFakeDynamoClient({
+      state: 'abc123',
+      code: 'the_fake_authorization_code',
+      refresh_token: '',
+      redirect_uri: "http://localhost/thisDoesNotMatter",
+    });
+    validateToken = (access_token) => {
+      return { va_identifiers: { icn: '0000000000000' } };
+    };
+    let res = new MockExpressResponse();
+    let client = buildOpenIDClient({
+      grant: (resolve, _reject) => {
+        resolve(new TokenSet({
+          access_token: "eyJraWQiOiJDcnNSZDNpYnhIMUswSl9WYWd0TnlHaER2cFlRN0hLdVd6NFFibk5IQmlBIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULk41Qlg4d3RXN01jSlp4ZDlqX0FfLVozVFA1LWI5Mk5fZ3E1MXRMY2w1VXcuUUFjTlo1d3JpL1ZhMUx4UGZ4b2ZjU3RvbkpKMnM0b0d0SzI5RDZFdGpsRT0iLCJpc3MiOiJodHRwczovL2RlcHR2YS1ldmFsLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTU3ODU4NTQ1MSwiZXhwIjoxNTc4NTg5MDUxLCJjaWQiOiIwb2EzNXJsYjhwdEh1bGVGZjJwNyIsInVpZCI6IjAwdTJwOWZhcjRpaERBRVg4MnA3Iiwic2NwIjpbIm9mZmxpbmVfYWNjZXNzIiwicGF0aWVudC9QYXRpZW50LnJlYWQiLCJsYXVuY2gvcGF0aWVudCIsInZldGVyYW5fc3RhdHVzLnJlYWQiLCJvcGVuaWQiLCJwcm9maWxlIl0sInN1YiI6ImNmYTMyMjQ0NTY5ODQxYTA5MGFkOWQyZjA1MjRjZjM4In0.NN8kTau8BKOycr_8BQKvV9_BnNgXjC1LkP2f85lTKcz8n1soAXqcfDJpDpndt7ihGgdd7AbDQIwaQwW6j9NPg9wr98G7kPfaFNIqJTsjj1FvHw9kwIK74l1CB0nQoRs-Yl-g26c6Z9fvOkSsTbFzGwFoTLp3dox6-vt18C5ql8vfPyNyooIZ9C1V2myEtYgoKpWHH1mx_Sx1ySRInuIOsoUYFJmRw87BMbb9F3n_IF377hJNy9tVNJFS78O9ZvnFWzUOQsx5qCtMGRkHEQFRQsK4Zo8Nd-Gc1_rjVwklfDeQlNd2uPEklGkbxCEZd2rIuWU4fIPPkENN6TKrVUtzjg",
+          expires_in: 60
+        }));
+      }
+    });
+    issuer = new FakeIssuer(client);
+    await tokenHandler(config, redirect_uri, logger, issuer, dynamo, dynamoClient, validateToken, req, res, next);
+    expect(client.grant).toHaveBeenCalled();
+    expect(res.statusCode).toEqual(200);
+  });
+
+  it('handles the refresh flow', async () => {
+    let req = new MockExpressRequest({
+      body: {
+        'grant_type': 'refresh_token',
+        'refresh_token': 'the_fake_refresh_token',
+        'client_id': 'client123',
+        'client_secret': 'secret789',
+      }
+    });
+    dynamoClient = buildFakeDynamoClient({
+      state: 'abc123',
+      code: 'xyz789',
+      refresh_token: 'the_fake_refresh_token',
+      redirect_uri: "http://localhost/thisDoesNotMatter",
+    });
+    validateToken = (access_token) => {
+      return { va_identifiers: { icn: '0000000000000' } };
+    };
+    let res = new MockExpressResponse();
+    let client = buildOpenIDClient({
+      refresh: (resolve, _reject) => {
+        resolve(new TokenSet({
+          access_token: "eyJraWQiOiJDcnNSZDNpYnhIMUswSl9WYWd0TnlHaER2cFlRN0hLdVd6NFFibk5IQmlBIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULk41Qlg4d3RXN01jSlp4ZDlqX0FfLVozVFA1LWI5Mk5fZ3E1MXRMY2w1VXcuUUFjTlo1d3JpL1ZhMUx4UGZ4b2ZjU3RvbkpKMnM0b0d0SzI5RDZFdGpsRT0iLCJpc3MiOiJodHRwczovL2RlcHR2YS1ldmFsLm9rdGEuY29tL29hdXRoMi9kZWZhdWx0IiwiYXVkIjoiYXBpOi8vZGVmYXVsdCIsImlhdCI6MTU3ODU4NTQ1MSwiZXhwIjoxNTc4NTg5MDUxLCJjaWQiOiIwb2EzNXJsYjhwdEh1bGVGZjJwNyIsInVpZCI6IjAwdTJwOWZhcjRpaERBRVg4MnA3Iiwic2NwIjpbIm9mZmxpbmVfYWNjZXNzIiwicGF0aWVudC9QYXRpZW50LnJlYWQiLCJsYXVuY2gvcGF0aWVudCIsInZldGVyYW5fc3RhdHVzLnJlYWQiLCJvcGVuaWQiLCJwcm9maWxlIl0sInN1YiI6ImNmYTMyMjQ0NTY5ODQxYTA5MGFkOWQyZjA1MjRjZjM4In0.NN8kTau8BKOycr_8BQKvV9_BnNgXjC1LkP2f85lTKcz8n1soAXqcfDJpDpndt7ihGgdd7AbDQIwaQwW6j9NPg9wr98G7kPfaFNIqJTsjj1FvHw9kwIK74l1CB0nQoRs-Yl-g26c6Z9fvOkSsTbFzGwFoTLp3dox6-vt18C5ql8vfPyNyooIZ9C1V2myEtYgoKpWHH1mx_Sx1ySRInuIOsoUYFJmRw87BMbb9F3n_IF377hJNy9tVNJFS78O9ZvnFWzUOQsx5qCtMGRkHEQFRQsK4Zo8Nd-Gc1_rjVwklfDeQlNd2uPEklGkbxCEZd2rIuWU4fIPPkENN6TKrVUtzjg",
+          refresh_token: 'the_fake_refresh_token',
+          expires_in: 60
+        }));
+      }
+    });
+    issuer = new FakeIssuer(client);
+    await tokenHandler(config, redirect_uri, logger, issuer, dynamo, dynamoClient, validateToken, req, res, next);
+    expect(client.refresh).toHaveBeenCalled();
+    expect(res.statusCode).toEqual(200);
+  });
+
+  it('supports client_secret_basic authentication', async () => { 
+    let req = new MockExpressRequest({
+      headers: {
+        'authorization': encodeBasicAuthHeader('client123', 'secret789'),
+      },
+      body: {
+        'grant_type': 'refresh_token',
+        'refresh_token': 'the_fake_refresh_token',
+      }
+    });
+    let res = new MockExpressResponse();
+    let client = buildExpiredRefreshTokenClient();
+    issuer = new FakeIssuer(client);
+    await tokenHandler(config, redirect_uri, logger, issuer, dynamo, dynamoClient, validateToken, req, res, next);
+    expect(client.refresh).toHaveBeenCalled();
+    expect(res.statusCode).toEqual(400);
+  });
+
+  it('supports client_secret_post authentication', async () => {
+    let req = new MockExpressRequest({
+      body: {
+        'grant_type': 'refresh_token',
+        'refresh_token': 'the_fake_refresh_token',
+        'client_id': 'client123',
+        'client_secret': 'secret789',
+      }
+    });
+    let res = new MockExpressResponse();
+    let client = buildExpiredRefreshTokenClient();
+    issuer = new FakeIssuer(client);
+    await tokenHandler(config, redirect_uri, logger, issuer, dynamo, dynamoClient, validateToken, req, res, next);
+    expect(client.refresh).toHaveBeenCalled();
+    expect(res.statusCode).toEqual(400);
+  });
+
+  it('errors properly for unauthorized requests', async () => {
+    let req = new MockExpressRequest({
+      method: 'POST',
+      url: '/oauth2/token',
+      body: {}, 
+    });
+    let res = new MockExpressResponse();
+    await tokenHandler(config, redirect_uri, logger, issuer, dynamo, dynamoClient, validateToken, req, res, next);
+    expect(validateToken).not.toHaveBeenCalled();
+    expect(res.statusCode).toEqual(401);
   });
 });
 

--- a/oauth-proxy/tests/testUtils.js
+++ b/oauth-proxy/tests/testUtils.js
@@ -1,0 +1,28 @@
+function buildDynamoAttributeValue(value) {
+  // BEWARE: This doesn't work with number sets and a few other Dynamo types.
+  if (value.constructor === String) {
+    return { "S": value };
+  } else if (value.constructor === Number) {
+    return { "N": value.toString() };
+  } else if (value.constructor === Boolean) {
+    return { "BOOL": value };
+  } else if (value.constructor === Array) {
+    return { "L": value.map((x) => { buildDynamoAttributeValue(x) }) };
+  } else if (value.constructor === Object) {
+    return { "M": convertObjectToDynamoAttributeValues(value) };
+  } else {
+    throw new Error("Unknown type.");
+  }
+}
+
+function convertObjectToDynamoAttributeValues(obj) {
+  return Object.entries(obj).reduce((accum, pair) => {
+    accum[pair[0]] = buildDynamoAttributeValue(pair[1]);
+    return accum;
+  }, {});
+}
+
+module.exports = {
+  buildDynamoAttributeValue,
+  convertObjectToDynamoAttributeValues,
+};

--- a/oauth-proxy/utils.js
+++ b/oauth-proxy/utils.js
@@ -21,8 +21,14 @@ const rethrowIfRuntimeError = (err) => {
   }
 };
 
+function encodeBasicAuthHeader(username, password) {
+  const encodedCredentials = Buffer.from(`${username}:${password}`).toString('base64');
+  return `Basic ${encodedCredentials}`;
+}
+
 module.exports = {
   isRuntimeError,
   rethrowIfRuntimeError,
   statusCodeFromError,
+  encodeBasicAuthHeader,
 }


### PR DESCRIPTION
This should fix [bug #4029](https://github.com/department-of-veterans-affairs/vets-contrib/issues/4029). Essentially the `tokenHandler` error paths were failing to `return`, so we tried to continue processing the request after the error. In addition to that, both error and success paths were not properly calling the `next` expressjs callback. I found this while trying to write the new tests for `tokenHandler` in `oauthHandlers.test.js`. Yay testing! :) 