### PR TITLE
Add functional test cases for mhv and dslogin

### DIFF
--- a/saml-proxy/test/e2e.test.js
+++ b/saml-proxy/test/e2e.test.js
@@ -203,10 +203,10 @@ describe('Logins for idp', () => {
         expect(icn).toEqual('123');
       });
 
-      it('looks up user from vso if the lookup from mvi fails', async () => {
+      it('treats the user as a VSO if the lookup from mvi fails', async () => {
         const requestSamlResponse = await buildSamlResponse(idp, '3');
         vetsApiClient.findUserInMVI = false;
-        vetsApiClient.findUserInVSO = true;
+        vetsApiClient.userIsVSO = true;
         const response = await ssoRequest(requestSamlResponse);
 
         expect(responseResultType(response)).toEqual(SAML_RESPONSE);
@@ -216,10 +216,10 @@ describe('Logins for idp', () => {
         expect(icn).toBeUndefined();
       });
 
-      it('returns a user not found page when the user is not found in mvi or vso', async () => {
+      it('returns a user not found page when the user is not found in mvi or is not a VSO', async () => {
         const requestSamlResponse = await buildSamlResponse(idp, '3');
         vetsApiClient.findUserInMVI = false;
-        vetsApiClient.findUserInVSO = false;
+        vetsApiClient.userIsVSO = false;
         const response = await ssoRequest(requestSamlResponse);
         expect(responseResultType(response)).toEqual(USER_NOT_FOUND);
       });

--- a/saml-proxy/test/e2e.test.js
+++ b/saml-proxy/test/e2e.test.js
@@ -6,7 +6,7 @@ import { DOMParser } from 'xmldom';
 
 import { buildBackgroundServerModule } from '../../common/backgroundServer';
 import { getTestExpressApp, idpConfig } from './testServer';
-import { MHV_USER, DSLOGIN_USER, IDME_USER, getUser } from './testUsers';
+import { MHV_USER, DSLOGON_USER, IDME_USER, getUser } from './testUsers';
 import MockVetsApiClient from './mockVetsApiClient';
 
 const { startServerInBackground, stopBackgroundServer } = buildBackgroundServerModule("saml-proxy test app");
@@ -182,7 +182,7 @@ describe('Logins for idp', () => {
     expect(state).toEqual(expectedState);
   });
 
-  for(const idp of [IDME_USER, MHV_USER, DSLOGIN_USER]) {
+  for(const idp of [IDME_USER, MHV_USER, DSLOGON_USER]) {
     describe(idp, () => {
       it('redirects to the verify identity page the if user is not loa3 verified', async () => {
         const requestSamlResponse = await buildSamlResponse(idp, '2');

--- a/saml-proxy/test/mockVetsApiClient.ts
+++ b/saml-proxy/test/mockVetsApiClient.ts
@@ -1,8 +1,11 @@
 import { SAMLUser } from '../src/VetsAPIClient';
 
 export default class MockVetsApiClient {
+  public findUserInMVI = true;
+  public findUserInVSO = true;
+
   public async getMVITraitsForLoa3User(user: SAMLUser) : Promise<{ icn: string, first_name: string, last_name: string }> {
-    if(user.firstName == 'mvi') {
+    if(this.findUserInMVI) {
       return {
         icn: '123',
         first_name: user.firstName,
@@ -14,12 +17,17 @@ export default class MockVetsApiClient {
   }
 
   public async getVSOSearch(firstName: string, lastName: string) : Promise<{poa: string}> {
-    if(firstName == 'vso') {
+    if(this.findUserInVSO) {
       return {
         poa: 'poa'
       };
     }
 
     throw new Error('Not found');
+  }
+
+  public reset() {
+    this.findUserInMVI = true;
+    this.findUserInVSO = true;
   }
 }

--- a/saml-proxy/test/mockVetsApiClient.ts
+++ b/saml-proxy/test/mockVetsApiClient.ts
@@ -2,7 +2,7 @@ import { SAMLUser } from '../src/VetsAPIClient';
 
 export default class MockVetsApiClient {
   public findUserInMVI = true;
-  public findUserInVSO = true;
+  public userIsVSO = true;
 
   public async getMVITraitsForLoa3User(user: SAMLUser) : Promise<{ icn: string, first_name: string, last_name: string }> {
     if(this.findUserInMVI) {
@@ -17,7 +17,7 @@ export default class MockVetsApiClient {
   }
 
   public async getVSOSearch(firstName: string, lastName: string) : Promise<{poa: string}> {
-    if(this.findUserInVSO) {
+    if(this.userIsVSO) {
       return {
         poa: 'poa'
       };
@@ -28,6 +28,6 @@ export default class MockVetsApiClient {
 
   public reset() {
     this.findUserInMVI = true;
-    this.findUserInVSO = true;
+    this.userIsVSO = true;
   }
 }

--- a/saml-proxy/test/testServer.js
+++ b/saml-proxy/test/testServer.js
@@ -6,7 +6,6 @@ import configureExpress from "../src/routes";
 import SPConfig from "../src/SPConfig";
 import { removeHeaders } from '../src/utils';
 
-import MockVetsApiClient from './mockVetsApiClient';
 import {
   idpCert,
   idpKey,
@@ -46,10 +45,9 @@ const defaultTestingConfig = {
 
 export const idpConfig = new IDPConfig(defaultTestingConfig);
 
-export function getApp() {
+export function getTestExpressApp(vetsApiClient) {
   const app = express();
   const spConfig = new SPConfig(defaultTestingConfig);
-  const vetsApiClient = new MockVetsApiClient();
   configureExpress(app, defaultTestingConfig, idpConfig, spConfig, vetsApiClient);
   return app;
 }

--- a/saml-proxy/test/testUsers.js
+++ b/saml-proxy/test/testUsers.js
@@ -1,0 +1,73 @@
+export const MHV_USER = 'mhv';
+export const IDME_USER = 'idme';
+export const DSLOGIN_USER = 'dslogin';
+
+function mhvUser(level_of_assurance) {
+  const loa = level_of_assurance === '3' ? 'Premium' : 'Standard';
+  return {
+    issuer: 'test',
+    userName: 'ae9ff5f4e4b741389904087d94cd19b2',
+    nameIdFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+    claims: {
+      email: 'va.api.user+idme.001@gmail.com',
+      mhv_profile: `{"accountType":"${loa}","availableServices":{"21":"VA Medications"}}`,
+      level_of_assurance: '0',
+      multifactor: 'true',
+      mhv_uuid: 'ae9ff5f4e4b741389904087d94cd19b2',
+      uuid: 'ae9ff5f4e4b741389904087d94cd19b2',
+    }
+  }
+}
+
+function dsloginUser(level_of_assurance) {
+  const loa = level_of_assurance === '3' ? '3' : '1'
+  return {
+    issuer: 'test',
+    userName: 'ae9ff5f4e4b741389904087d94cd19b2',
+    nameIdFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+    claims: {
+      dslogon_birth_date: '1998-01-23',
+      email: 'va.api.user+idme.001@gmail.com',
+      dslogon_fname: 'TAMERA',
+      dslogon_uuid: '1234567890',
+      dslogon_gender: 'female',
+      dslogon_lname: 'ELLIS',
+      level_of_assurance: '0',
+      dslogon_assurance: loa,
+      dslogon_mname: 'E',
+      multifactor: 'true',
+      uuid: 'ae9ff5f4e4b741389904087d94cd19b2'
+    }
+  }
+}
+
+function idmUser(level_of_assurance) {
+  return {
+    issuer: 'test',
+    userName: 'ae9ff5f4e4b741389904087d94cd19b2',
+    nameIdFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+    claims: {
+      birth_date: '1998-01-23',
+      email: 'va.api.user+idme.001@gmail.com',
+      fname: 'TAMERA',
+      social: '123456789',
+      gender: 'female',
+      lname: 'ELLIS',
+      level_of_assurance: level_of_assurance,
+      mname: 'E',
+      multifactor: 'true',
+      uuid: 'ae9ff5f4e4b741389904087d94cd19b2'
+    }
+  };
+}
+
+export function getUser(type, level_of_assurance) {
+  switch(type) {
+    case IDME_USER:
+      return idmUser(level_of_assurance);
+    case DSLOGIN_USER:
+      return dsloginUser(level_of_assurance);
+    case MHV_USER:
+      return mhvUser(level_of_assurance);
+  }
+}

--- a/saml-proxy/test/testUsers.js
+++ b/saml-proxy/test/testUsers.js
@@ -41,7 +41,7 @@ function dsloginUser(level_of_assurance) {
   }
 }
 
-function idmUser(level_of_assurance) {
+function idmeUser(level_of_assurance) {
   return {
     issuer: 'test',
     userName: 'ae9ff5f4e4b741389904087d94cd19b2',
@@ -64,7 +64,7 @@ function idmUser(level_of_assurance) {
 export function getUser(type, level_of_assurance) {
   switch(type) {
     case IDME_USER:
-      return idmUser(level_of_assurance);
+      return idmeUser(level_of_assurance);
     case DSLOGIN_USER:
       return dsloginUser(level_of_assurance);
     case MHV_USER:

--- a/saml-proxy/test/testUsers.js
+++ b/saml-proxy/test/testUsers.js
@@ -1,6 +1,6 @@
 export const MHV_USER = 'mhv';
 export const IDME_USER = 'idme';
-export const DSLOGIN_USER = 'dslogin';
+export const DSLOGON_USER = 'dslogon';
 
 function mhvUser(level_of_assurance) {
   const loa = level_of_assurance === '3' ? 'Premium' : 'Standard';
@@ -19,7 +19,7 @@ function mhvUser(level_of_assurance) {
   }
 }
 
-function dsloginUser(level_of_assurance) {
+function dslogonUser(level_of_assurance) {
   const loa = level_of_assurance === '3' ? '3' : '1'
   return {
     issuer: 'test',
@@ -65,8 +65,8 @@ export function getUser(type, level_of_assurance) {
   switch(type) {
     case IDME_USER:
       return idmeUser(level_of_assurance);
-    case DSLOGIN_USER:
-      return dsloginUser(level_of_assurance);
+    case DSLOGON_USER:
+      return dslogonUser(level_of_assurance);
     case MHV_USER:
       return mhvUser(level_of_assurance);
   }


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-contrib/issues/1352

Major changes from the [last PR](https://github.com/department-of-veterans-affairs/vets-saml-proxy/pull/82) are the mock vets-api client is easier to control and the user in the SAMLResponse hitting the `sso` endpoint can be from `idme`, `mhv` or `dslogin`. Note the loop in the e2e test that runs the same tests for all three identity providers.