### PR TITLE
Fix oauth refresh timeouts

### DIFF
--- a/oauth-proxy/dev-config.base.json
+++ b/oauth-proxy/dev-config.base.json
@@ -1,10 +1,11 @@
 {
   "host": "http://localhost:7100",
-  "well_known_base_path": "/services/oauth2",
+  "well_known_base_path": "/oauth2",
   "upstream_issuer": "https://deptva-eval.okta.com/oauth2/default",
   "dynamo_local": "dynamodb:8000",
   "dynamo_table_name": "OAuthRequests",
   "okta_url": "https://deptva-eval.okta.com",
-  "validate_endpoint": "https://dev-api.va.gov/services/auth/v0/validate",
-  "validate_apiKey": "<FIX ME>"
+  "validate_endpoint": "https://dev-api.va.gov/internal/auth/v0/validation",
+  "validate_apiKey": "<FIX ME>",
+  "okta_token": "<FIX ME>"
 }

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -150,28 +150,31 @@ function buildApp(config, issuer, oktaClient, dynamo, dynamoClient, validateToke
     res.json(filteredMetadata);
   });
 
-  router.get(appRoutes.jwks, async (req, res) => {
+  router.get(appRoutes.jwks, (req, res) => {
     req.pipe(request(issuer.metadata.jwks_uri)).pipe(res)
   });
 
-  router.get(appRoutes.userinfo, async (req, res) => {
+  router.get(appRoutes.userinfo, (req, res) => {
     req.pipe(request(issuer.metadata.userinfo_endpoint)).pipe(res)
   });
 
-  router.post(appRoutes.introspection, async (req, res) => {
+  router.post(appRoutes.introspection, (req, res) => {
     req.pipe(request(issuer.metadata.introspection_endpoint)).pipe(res)
   });
 
   router.get(appRoutes.redirect, async (req, res, next) => {
-    await oauthHandlers.redirectHandler(logger, dynamo, dynamoClient, req, res, next);
+    await oauthHandlers.redirectHandler(logger, dynamo, dynamoClient, req, res, next)
+      .catch(next)
   });
 
   router.get(appRoutes.authorize, async (req, res, next) => {
     await oauthHandlers.authorizeHandler(config, redirect_uri, logger, issuer, dynamo, dynamoClient, oktaClient, req, res, next)
+      .catch(next)
   });
 
   router.post(appRoutes.token, async (req, res, next) => {
     await oauthHandlers.tokenHandler(config, redirect_uri, logger, issuer, dynamo, dynamoClient, validateToken, req, res, next)
+      .catch(next)
   });
 
   app.use(well_known_base_path, router)

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -180,8 +180,6 @@ function buildApp(config, issuer, oktaClient, dynamo, dynamoClient, validateToke
   app.use(well_known_base_path, router)
 
   // Error handlers. Keep as last middleware
-  // If we have error and description as query params display them, otherwise go to the
-  // catchall error handler
   if (useSentry) {
     if (useSentry) {
       app.use(Sentry.Handlers.errorHandler({
@@ -196,6 +194,10 @@ function buildApp(config, issuer, oktaClient, dynamo, dynamoClient, validateToke
   }
 
   app.use(function (err, req, res, next) {
+    logger.error(err);
+
+    // If we have error and description as query params display them, otherwise go to the
+    // catchall error handler
     const { error, error_description } = req.query;
     if (error && error_description) {
       res.status(500).send(`${error}: ${error_description}`);

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -179,18 +179,18 @@ function buildApp(config, issuer, oktaClient, dynamo, dynamoClient, validateToke
 
   app.use(well_known_base_path, router)
 
-  // Error handlers. Keep as last middleware
+  // Error handlers. Keep as last middlewares
+
+  // Sentry error handler must be the first error handling middleware
   if (useSentry) {
-    if (useSentry) {
-      app.use(Sentry.Handlers.errorHandler({
-        shouldHandleError(error) {
-          if (error.status >= 400) {
-            return true
-          }
-          return false
-        }
-      }));
-    }
+    app.use(Sentry.Handlers.errorHandler({
+      shouldHandleError(error) {
+        // Report 4xx and 5xx errors to sentry.
+        // Including 4xx errors is a temporary change to get more insight
+        // into errors reported by our users
+        return error.status >= 400
+      }
+    }));
   }
 
   app.use(function (err, req, res, next) {


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/vets-contrib/issues/4132

See https://lighthouseva.slack.com/archives/CMT4MFPS6/p1580154255007800 and https://lighthouseva.slack.com/archives/CGG5E8CUU/p1580220425011000 for additional context.

This PR fixes a small programming error (using `document.state.S` when `document` might be `undefined`) and ensures that we will actually send a 500 response when encountering an unexpected error. Additionally, it modifies the refresh handler so that errors retrieving the `state` param from DynamoDB will only prevent the `state` from being included in the response, rather than sending an error to the user.


