### PR TITLE
PIV-280 - Configurable OIDC timeout

### DIFF
--- a/oauth-proxy/cli.js
+++ b/oauth-proxy/cli.js
@@ -20,7 +20,7 @@ function processArgs() {
       },
       upstream_issuer_timeout_ms: {
         description: 'Optional timeout (ms) for upstream requests',
-        required: false,
+        required: false
       },
       aws_secret: {
         description: "AWS Secret Access Key",

--- a/oauth-proxy/cli.js
+++ b/oauth-proxy/cli.js
@@ -18,6 +18,10 @@ function processArgs() {
         description: 'URI of upstream issuer to be proxies',
         required: true,
       },
+      upstream_issuer_timeout_ms: {
+        description: 'Optional timeout (ms) for upstream requests',
+        required: false,
+      },
       aws_secret: {
         description: "AWS Secret Access Key",
         required: false,

--- a/oauth-proxy/dev-config.base.json
+++ b/oauth-proxy/dev-config.base.json
@@ -2,6 +2,7 @@
   "host": "http://localhost:7100",
   "well_known_base_path": "/oauth2",
   "upstream_issuer": "https://deptva-eval.okta.com/oauth2/default",
+  "upstream_issuer_timeout_ms": 15000,
   "dynamo_local": "dynamodb:8000",
   "dynamo_table_name": "OAuthRequests",
   "okta_url": "https://deptva-eval.okta.com",

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -2,13 +2,10 @@ const express = require('express');
 const cors = require('cors');
 const { Issuer } = require('openid-client');
 const process = require('process');
-const { URLSearchParams } = require('url');
 const bodyParser = require('body-parser');
 const request = require('request');
-const jwtDecode = require('jwt-decode');
 const dynamoClient = require('./dynamo_client');
 const { processArgs } = require('./cli');
-const { statusCodeFromError } = require('./utils');
 const okta = require('@okta/okta-sdk-nodejs');
 const morgan = require('morgan');
 const promBundle = require('express-prom-bundle');
@@ -49,6 +46,9 @@ const openidMetadataWhitelist = [
 ]
 
 async function createIssuer(config) {
+  if (config.upstream_issuer_timeout_ms) {
+    Issuer.defaultHttpOptions = { timeout: config.upstream_issuer_timeout_ms };
+  }
   return await Issuer.discover(config.upstream_issuer);
 }
 


### PR DESCRIPTION
https://vasdvp.atlassian.net/browse/PIV-280

Adds an optional config to override the default 1500ms timeout for OIDC requests.

See https://github.com/department-of-veterans-affairs/devops/pull/6589 for related config changes (15s timeout in non-prod environments).