### PR TITLE
Change Entrypoint to not use entrypoint script

### DIFF
--- a/oauth-proxy/Dockerfile
+++ b/oauth-proxy/Dockerfile
@@ -21,4 +21,4 @@ HEALTHCHECK --interval=1m --timeout=4s \
 
 USER node
 ENTRYPOINT ["/usr/local/bin/tini" "--"]
-ENTRYPOINT ["node", "index.js"]
+CMD ["node", "index.js"]

--- a/oauth-proxy/Dockerfile
+++ b/oauth-proxy/Dockerfile
@@ -20,5 +20,5 @@ HEALTHCHECK --interval=1m --timeout=4s \
   CMD wget localhost:7100/oauth2/.well-known/openid-configuration -q -O - > /dev/null 2>&1
 
 USER node
-ENTRYPOINT ["/usr/local/bin/tini" "--"]
+ENTRYPOINT ["/usr/local/bin/tini", "--"]
 CMD ["node", "index.js"]

--- a/oauth-proxy/Dockerfile
+++ b/oauth-proxy/Dockerfile
@@ -20,4 +20,5 @@ HEALTHCHECK --interval=1m --timeout=4s \
   CMD wget localhost:7100/oauth2/.well-known/openid-configuration -q -O - > /dev/null 2>&1
 
 USER node
+ENTRYPOINT ["/usr/local/bin/tini" "--"]
 ENTRYPOINT ["node", "index.js"]

--- a/oauth-proxy/docker-compose.yml
+++ b/oauth-proxy/docker-compose.yml
@@ -26,4 +26,4 @@ services:
       - AWS_DEFAULT_REGION=us-west-2
     volumes:
       - .:/opt/app
-    command: "node index.js--config dev-config.json"
+    command: "node index.js --config dev-config.json"

--- a/oauth-proxy/docker-compose.yml
+++ b/oauth-proxy/docker-compose.yml
@@ -26,4 +26,4 @@ services:
       - AWS_DEFAULT_REGION=us-west-2
     volumes:
       - .:/opt/app
-    command: "node build/app.js--config dev-config.json"
+    command: "node index.js--config dev-config.json"

--- a/oauth-proxy/docker-compose.yml
+++ b/oauth-proxy/docker-compose.yml
@@ -26,4 +26,4 @@ services:
       - AWS_DEFAULT_REGION=us-west-2
     volumes:
       - .:/opt/app
-    command: "--config dev-config.json"
+    command: "node build/app/js--config dev-config.json"

--- a/oauth-proxy/docker-compose.yml
+++ b/oauth-proxy/docker-compose.yml
@@ -26,4 +26,4 @@ services:
       - AWS_DEFAULT_REGION=us-west-2
     volumes:
       - .:/opt/app
-    command: "node build/app/js--config dev-config.json"
+    command: "node build/app.js--config dev-config.json"

--- a/saml-proxy/Dockerfile
+++ b/saml-proxy/Dockerfile
@@ -23,5 +23,5 @@ HEALTHCHECK --interval=1m --timeout=4s \
 RUN chown -R node:node /home/node 
 
 USER node
-ENTRYPOINT ["/usr/local/bin/tini" "--"]
+ENTRYPOINT ["/usr/local/bin/tini", "--"]
 CMD ["node", "build/app.js"]

--- a/saml-proxy/Dockerfile
+++ b/saml-proxy/Dockerfile
@@ -23,4 +23,5 @@ HEALTHCHECK --interval=1m --timeout=4s \
 RUN chown -R node:node /home/node 
 
 USER node
+ENTRYPOINT ["/usr/local/bin/tini" "--"]
 CMD ["node", "build/app.js"]

--- a/saml-proxy/docker-compose.yml
+++ b/saml-proxy/docker-compose.yml
@@ -7,4 +7,4 @@ services:
     ports:
       - "7000:7000"
     network_mode: "host"
-    command: '--config dev-config.json'
+    command: 'node build/app.js --config dev-config.json'


### PR DESCRIPTION
Right now since we are running on two separate platforms, the entrypoint script does not function correctly. 

This bypasses it.

I will create a separate Dockerfile for the fargate process that will not affect this.