### PR TITLE
Fix Docker healthchecks by using a nodejs healthcheck

### DIFF
--- a/oauth-proxy/Dockerfile
+++ b/oauth-proxy/Dockerfile
@@ -16,8 +16,8 @@ COPY --chown=node:node ./common /home/common
 
 EXPOSE 7100 7100
 
-HEALTHCHECK --interval=1m --timeout=4s \
-  CMD wget localhost:7100/oauth2/.well-known/openid-configuration -q -O - > /dev/null 2>&1
+HEALTHCHECK --interval=1m --timeout=4s --start-period=30s \
+  CMD node bin/healthcheck.js
 
 USER node
 ENTRYPOINT ["/usr/local/bin/tini", "--"]

--- a/oauth-proxy/bin/healthcheck.js
+++ b/oauth-proxy/bin/healthcheck.js
@@ -1,0 +1,24 @@
+var http = require("http");
+
+var options = {
+    host: "localhost",
+    port: "7100",
+    path: "/oauth2/.well-known/openid-configuration",
+    timeout: 2000
+};
+
+var request = http.request(options, (res) => {
+    console.log(`STATUS: ${res.statusCode}`);
+    if (res.statusCode == 200) {
+        process.exit(0);
+    } else {
+        process.exit(1);
+    }
+});
+
+request.on('error', function (err) {
+    console.log('ERROR');
+    process.exit(1);
+});
+
+request.end();

--- a/saml-proxy/Dockerfile
+++ b/saml-proxy/Dockerfile
@@ -17,8 +17,8 @@ COPY --chown=node:node ./common /home/common
 EXPOSE 7000 7000
 
 RUN ./node_modules/.bin/tsc
-HEALTHCHECK --interval=1m --timeout=4s \
-  CMD wget localhost:7000/samlproxy/idp/metadata -q -O - > /dev/null 2>&1
+HEALTHCHECK --interval=1m --timeout=4s --start-period=30s \
+  CMD node bin/healthcheck.js
 
 RUN chown -R node:node /home/node 
 

--- a/saml-proxy/bin/healthcheck.js
+++ b/saml-proxy/bin/healthcheck.js
@@ -1,0 +1,24 @@
+var http = require("http");
+
+var options = {
+    host: "localhost",
+    port: "7000",
+    path: "/samlproxy/idp/metadata",
+    timeout: 2000
+};
+
+var request = http.request(options, (res) => {
+    console.log(`STATUS: ${res.statusCode}`);
+    if (res.statusCode == 200) {
+        process.exit(0);
+    } else {
+        process.exit(1);
+    }
+});
+
+request.on('error', function (err) {
+    console.log('ERROR');
+    process.exit(1);
+});
+
+request.end();


### PR DESCRIPTION
Since wget, curl, and iwr are all external dependencies, and these services are written in NodeJS, it makes sense to write the healthcheck in NodeJS as well, as the container will _always_ have Node installed.

```[node@f2c91c8b6955 ~]$ ssm-parent --plain-path /dvp/staging/saml-proxy run -- node build/app.js &
[1] 204
[node@f2c91c8b6955 ~]$ {
  "service": "saml-proxy",
  "env": "development",
  "port": 7000,
  "level": "info",
  "message": "Starting proxy server on port 7000 in development mode",
  "time": "2020-04-14T22:11:09.515Z"
}
[node@f2c91c8b6955 ~]$ node bin/healthcheck.js
{
  "remote-address": "::ffff:127.0.0.1",
  "time": "2020-04-14T22:11:57.522Z",
  "method": "GET",
  "url": "/samlproxy/idp/metadata",
  "status-code": "200",
  "content-length": "3763"
}
STATUS: 200
[node@f2c91c8b6955 ~]$ kill -9 204
[node@f2c91c8b6955 ~]$ node bin/healthcheck.js
ERROR
[1]+  Killed                  ssm-parent --plain-path /dvp/staging/saml-proxy run -- node build/app.js
```