### PR TITLE
Use a separate Dockerfile to run the Codebuild/Fargate pipeline

### DIFF
--- a/oauth-proxy/DockerfileFG
+++ b/oauth-proxy/DockerfileFG
@@ -1,0 +1,23 @@
+FROM vasdvp/lighthouse-node-application-base:node12
+
+WORKDIR /home/node
+
+RUN git config --global url."https://".insteadOf git://
+COPY --chown=node:node ./oauth-proxy/package.json package.json
+COPY --chown=node:node ./oauth-proxy/package-lock.json package-lock.json
+RUN npm install
+
+USER root
+RUN mkdir -p /home/common && \
+  chown -R node:node /home/common
+
+COPY --chown=node:node ./oauth-proxy ./
+COPY --chown=node:node ./common /home/common
+
+EXPOSE 7100 7100
+
+HEALTHCHECK --interval=1m --timeout=4s --start-period=30s \
+  CMD node bin/healthcheck.js
+
+USER node
+CMD ["node", "index.js"]

--- a/oauth-proxy/buildspec.yml
+++ b/oauth-proxy/buildspec.yml
@@ -13,7 +13,7 @@ phases:
     commands:
       - echo Build started on `date`
       - echo Building the Docker image...
-      - docker build -t dvp/oauth-proxy:$CODEBUILD_RESOLVED_SOURCE_VERSION -f oauth-proxy/Dockerfile .
+      - docker build -t dvp/oauth-proxy:$CODEBUILD_RESOLVED_SOURCE_VERSION -f oauth-proxy/DockerfileFG .
       - docker tag dvp/oauth-proxy:$CODEBUILD_RESOLVED_SOURCE_VERSION $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/dvp/oauth-proxy:$CODEBUILD_RESOLVED_SOURCE_VERSION
   post_build:
     commands:

--- a/saml-proxy/DockerfileFG
+++ b/saml-proxy/DockerfileFG
@@ -1,0 +1,26 @@
+FROM vasdvp/lighthouse-node-application-base:node12
+
+WORKDIR /home/node
+
+RUN git config --global url."https://".insteadOf git://
+COPY --chown=node:node ./saml-proxy/package.json package.json
+COPY --chown=node:node ./saml-proxy/package-lock.json package-lock.json
+RUN npm install
+
+USER root
+RUN mkdir -p /home/common && \
+  chown -R node:node /home/common
+
+COPY --chown=node:node ./saml-proxy ./
+COPY --chown=node:node ./common /home/common
+
+EXPOSE 7000 7000
+
+RUN ./node_modules/.bin/tsc
+HEALTHCHECK --interval=1m --timeout=4s --start-period=30s \
+  CMD node bin/healthcheck.js
+
+RUN chown -R node:node /home/node 
+
+USER node
+CMD ["node", "build/app.js"]

--- a/saml-proxy/buildspec.yml
+++ b/saml-proxy/buildspec.yml
@@ -13,7 +13,7 @@ phases:
     commands:
       - echo Build started on `date`
       - echo Building the Docker image...
-      - docker build -t dvp/saml-proxy:$CODEBUILD_RESOLVED_SOURCE_VERSION -f saml-proxy/Dockerfile .
+      - docker build -t dvp/saml-proxy:$CODEBUILD_RESOLVED_SOURCE_VERSION -f saml-proxy/DockerfileFG .
       - docker tag dvp/saml-proxy:$CODEBUILD_RESOLVED_SOURCE_VERSION $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/dvp/saml-proxy:$CODEBUILD_RESOLVED_SOURCE_VERSION
   post_build:
     commands:


### PR DESCRIPTION
Using the same dockerfile caused us to have a problem in sandbox and dev yesterday, so to prevent that from occurring again, I will use a separate Dockerfile to develop the pipeline.