### PR TITLE
Api 1741 fhir aud specifications

### DIFF
--- a/oauth-proxy/apiClients/axiosCachingAdapter.js
+++ b/oauth-proxy/apiClients/axiosCachingAdapter.js
@@ -5,7 +5,6 @@ const myCache = new NodeCache({useClones: false, stdTTL: 3600});
 const axiosCachingAdapter = (config) => {
     let response = myCache.get(config.url)
     if (response == undefined) {
-        console.log("not cached")
         return httpRequestAdapter(config)
     }
 

--- a/oauth-proxy/apiClients/axiosCachingAdapter.js
+++ b/oauth-proxy/apiClients/axiosCachingAdapter.js
@@ -1,0 +1,26 @@
+const httpAdapter = require('axios/lib/adapters/http');
+const NodeCache = require('node-cache')
+const myCache = new NodeCache({useClones: false, stdTTL: 3600});
+
+const axiosCachingAdapter = (config) => {
+    let response = myCache.get(config.url)
+    if (response == undefined) {
+        console.log("not cached")
+        return httpRequestAdapter(config)
+    }
+
+    return new Promise((resolve, reject) => resolve(response))
+}
+
+const httpRequestAdapter = (config) => {
+    return new Promise((resolve, reject) => {
+        httpAdapter(config).then((res) => {
+            myCache.set(config.url, res)
+            resolve(res)
+        }).catch((error) => {
+            reject(error)
+        })
+    })
+}
+
+module.exports = { axiosCachingAdapter };

--- a/oauth-proxy/apiClients/axiosCachingAdapter.js
+++ b/oauth-proxy/apiClients/axiosCachingAdapter.js
@@ -1,23 +1,23 @@
 const httpAdapter = require('axios/lib/adapters/http');
-const NodeCache = require('node-cache')
+const NodeCache = require('node-cache');
 const myCache = new NodeCache({useClones: false, stdTTL: 3600});
 
 const axiosCachingAdapter = (config) => {
-    let response = myCache.get(config.url)
+    let response = myCache.get(config.url);
     if (response == undefined) {
-        return httpRequestAdapter(config)
+        return httpRequestAdapter(config);
     }
 
-    return new Promise((resolve, reject) => resolve(response))
+    return new Promise((resolve, reject) => resolve(response));
 }
 
 const httpRequestAdapter = (config) => {
     return new Promise((resolve, reject) => {
         httpAdapter(config).then((res) => {
-            myCache.set(config.url, res)
-            resolve(res)
+            myCache.set(config.url, res);
+            resolve(res);
         }).catch((error) => {
-            reject(error)
+            reject(error);
         })
     })
 }

--- a/oauth-proxy/apiClients/oktaApiClient.js
+++ b/oauth-proxy/apiClients/oktaApiClient.js
@@ -64,4 +64,24 @@ const getClientInfo = async (config, clientId) => {
   return response;
 }
 
-module.exports = { deleteUserGrantOnClient, getUserInfo, getClientInfo };
+const getAuthorizationServerInfo = async (config, authorizationServerId) => {
+  let error;
+  let response;
+  const template = uriTemplates(config.okta_url+"api/v1/authorizationServers/{authorizationServerId}")
+
+  await axios({
+    method: "GET",
+    url: template.fill({authorizationServerId: authorizationServerId}),
+    headers: {Authorization: "SSWS "+config.okta_token}
+  }).then(res => {
+    response = res})
+  .catch(err => {error = err})
+
+  if(response == null){
+    throw error;
+  }
+
+  return response;
+}
+
+module.exports = { deleteUserGrantOnClient, getUserInfo, getClientInfo, getAuthorizationServerInfo };

--- a/oauth-proxy/apiClients/oktaApiClient.js
+++ b/oauth-proxy/apiClients/oktaApiClient.js
@@ -72,9 +72,8 @@ const getAuthorizationServerInfo = async (config, authorizationServerId) => {
     method: "GET",
     url: template.fill({authorizationServerId: authorizationServerId}),
     headers: {Authorization: "SSWS "+config.okta_token}
-  }).then(res => {
-    response = res.data})
-  .catch(err => {error = err})
+  }).then(res => response = res.data)
+  .catch(err => error = err)
 
   if(response == null){
     throw error;

--- a/oauth-proxy/apiClients/oktaApiClient.js
+++ b/oauth-proxy/apiClients/oktaApiClient.js
@@ -1,12 +1,12 @@
 const axios = require('axios');
 const uriTemplates = require('uri-templates');
 const URI = require('urijs');
-const { axiosCachingAdapter } = require('./axiosCachingAdapter')
+const { axiosCachingAdapter } = require('./axiosCachingAdapter');
 
 const deleteUserGrantOnClient = async (config, userId, clientId) => {
   let error;
   let response;
-  const template = uriTemplates(config.okta_url+"/api/v1/users/{userid}/clients/{clientid}/grants")
+  const template = uriTemplates(config.okta_url+"/api/v1/users/{userid}/clients/{clientid}/grants");
   await axios({
       method: "DELETE",
       url: template.fill({userid: userId, clientid: clientId}),
@@ -24,8 +24,8 @@ const deleteUserGrantOnClient = async (config, userId, clientId) => {
 
 const getUserInfo = async (config, email) => {
   let uri = URI(config.okta_url+"/api/v1/users");
-  let emailFilter = `profile.email eq "${email}"`
-  uri.search({filter: emailFilter})
+  let emailFilter = `profile.email eq "${email}"`;
+  uri.search({filter: emailFilter});
   
   let response;
   let error;
@@ -48,7 +48,7 @@ const getUserInfo = async (config, email) => {
 const getClientInfo = async (config, clientId) => {
   let error;
   let response;
-  const template = uriTemplates(config.okta_url+"/oauth2/v1/clients/{clientid}")
+  const template = uriTemplates(config.okta_url+"/oauth2/v1/clients/{clientid}");
 
   await axios({
     method: "GET",
@@ -68,7 +68,7 @@ const getClientInfo = async (config, clientId) => {
 const getAuthorizationServerInfo = async (config, authorizationServerId) => {
   let error;
   let response;
-  const template = uriTemplates(config.okta_url+"/api/v1/authorizationServers/{authorizationServerId}")
+  const template = uriTemplates(config.okta_url+"/api/v1/authorizationServers/{authorizationServerId}");
   await axios({
     method: "GET",
     url: template.fill({authorizationServerId: authorizationServerId}),

--- a/oauth-proxy/apiClients/oktaApiClient.js
+++ b/oauth-proxy/apiClients/oktaApiClient.js
@@ -67,14 +67,13 @@ const getClientInfo = async (config, clientId) => {
 const getAuthorizationServerInfo = async (config, authorizationServerId) => {
   let error;
   let response;
-  const template = uriTemplates(config.okta_url+"api/v1/authorizationServers/{authorizationServerId}")
-
+  const template = uriTemplates(config.okta_url+"/api/v1/authorizationServers/{authorizationServerId}")
   await axios({
     method: "GET",
     url: template.fill({authorizationServerId: authorizationServerId}),
     headers: {Authorization: "SSWS "+config.okta_token}
   }).then(res => {
-    response = res})
+    response = res.data})
   .catch(err => {error = err})
 
   if(response == null){

--- a/oauth-proxy/apiClients/oktaApiClient.js
+++ b/oauth-proxy/apiClients/oktaApiClient.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const uriTemplates = require('uri-templates');
 const URI = require('urijs');
+const { axiosCachingAdapter } = require('./axiosCachingAdapter')
 
 const deleteUserGrantOnClient = async (config, userId, clientId) => {
   let error;
@@ -71,7 +72,8 @@ const getAuthorizationServerInfo = async (config, authorizationServerId) => {
   await axios({
     method: "GET",
     url: template.fill({authorizationServerId: authorizationServerId}),
-    headers: {Authorization: "SSWS "+config.okta_token}
+    headers: {Authorization: "SSWS "+config.okta_token},
+    adapter: axiosCachingAdapter
   }).then(res => response = res.data)
   .catch(err => error = err)
 

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -239,14 +239,12 @@ function buildApp(config, issuer, oktaClient, dynamo, dynamoClient, validateToke
         // Report 4xx and 5xx errors to sentry.
         // Including 4xx errors is a temporary change to get more insight
         // into errors reported by our users
-        console.log("Sentry error handler");
         return error.status >= 400
       }
     }));
   }
 
   app.use(function (err, req, res, next) {
-    console.log("Index error handler")
     logger.error(err);
 
     // If we have error and description as query params display them, otherwise go to the

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -239,12 +239,14 @@ function buildApp(config, issuer, oktaClient, dynamo, dynamoClient, validateToke
         // Report 4xx and 5xx errors to sentry.
         // Including 4xx errors is a temporary change to get more insight
         // into errors reported by our users
+        console.log("Sentry error handler");
         return error.status >= 400
       }
     }));
   }
 
   app.use(function (err, req, res, next) {
+    console.log("Index error handler")
     logger.error(err);
 
     // If we have error and description as query params display them, otherwise go to the

--- a/oauth-proxy/oauthHandlers/authorizeHandler.js
+++ b/oauth-proxy/oauthHandlers/authorizeHandler.js
@@ -49,11 +49,11 @@ const authorizeHandler = async (config, redirect_uri, logger, issuer, dynamo, dy
 };
 
 const checkParameters = async (state, aud, config, issuer) => {
-  if(state == null) {
+  if(state == null || state == undefined) {
     throw {status: 400, error: "invalid_request", error_description: "State parameter required"};
   }
 
-  if(aud != null || aud != undefined) {
+  if(aud != null && aud != undefined) {
     let authorizationServerId = new URL(issuer.metadata.issuer).pathname.split('/').pop();
     let serverAudiences;
     

--- a/oauth-proxy/oauthHandlers/authorizeHandler.js
+++ b/oauth-proxy/oauthHandlers/authorizeHandler.js
@@ -49,11 +49,11 @@ const authorizeHandler = async (config, redirect_uri, logger, issuer, dynamo, dy
 };
 
 const checkParameters = async (state, aud, config, issuer) => {
-  if(state == null || state == undefined) {
+  if(!state) {
     throw {status: 400, error: "invalid_request", error_description: "State parameter required"};
   }
 
-  if(aud != null && aud != undefined) {
+  if(aud) {
     let authorizationServerId = new URL(issuer.metadata.issuer).pathname.split('/').pop();
     let serverAudiences;
     

--- a/oauth-proxy/oauthHandlers/authorizeHandler.js
+++ b/oauth-proxy/oauthHandlers/authorizeHandler.js
@@ -7,7 +7,7 @@ const authorizeHandler = async (config, redirect_uri, logger, issuer, dynamo, dy
   const { state, client_id, aud, redirect_uri: client_redirect } = req.query;
 
   try{
-    await checkParameters(state, aud, config, issuer)
+    await checkParameters(state, aud, config, issuer);
   }catch(err) {
     res.status(err.status).json({
       error: err.error,
@@ -45,7 +45,7 @@ const authorizeHandler = async (config, redirect_uri, logger, issuer, dynamo, dy
     params.set('idp', config.idp);
   }
 
-  res.redirect(`${issuer.metadata.authorization_endpoint}?${params.toString()}`)
+  res.redirect(`${issuer.metadata.authorization_endpoint}?${params.toString()}`);
 };
 
 const checkParameters = async (state, aud, config, issuer) => {
@@ -59,7 +59,8 @@ const checkParameters = async (state, aud, config, issuer) => {
     
     await getAuthorizationServerInfo(config, authorizationServerId)
     .then(res => {
-      serverAudiences = res.audiences})
+      serverAudiences = res.audiences;
+    })
     .catch(() => {
       throw {status: 500, error: "internal_error"};
     });

--- a/oauth-proxy/oauthHandlers/authorizeHandler.js
+++ b/oauth-proxy/oauthHandlers/authorizeHandler.js
@@ -1,16 +1,19 @@
-const { URLSearchParams } = require('url');
+const { URLSearchParams, URL } = require('url');
 const { loginBegin } = require('../metrics');
+const { getAuthorizationServerInfo } = require('../apiClients/oktaApiClient');
 
 const authorizeHandler = async (config, redirect_uri, logger, issuer, dynamo, dynamoClient, oktaClient, req, res, next) => {
   loginBegin.inc();
-  const { state, client_id, redirect_uri: client_redirect } = req.query;
+  const { state, client_id, aud, redirect_uri: client_redirect } = req.query;
 
-  if(state == null) {
-    res.status(400).json({
-      error: "invalid_request",
-      error_description: "State parameter required",
+  try{
+    await checkParameters(state, aud, config, issuer)
+  }catch(err) {
+    res.status(err.status).json({
+      error: err.error,
+      error_description: err.error_description,
     })
-    return next()
+    return next();
   }
 
   try {
@@ -44,5 +47,27 @@ const authorizeHandler = async (config, redirect_uri, logger, issuer, dynamo, dy
 
   res.redirect(`${issuer.metadata.authorization_endpoint}?${params.toString()}`)
 };
+
+const checkParameters = async (state, aud, config, issuer) => {
+  if(state == null) {
+    throw {status: 400, error: "invalid_request", error_description: "State parameter required"};
+  }
+
+  if(aud != null || aud != undefined) {
+    let authorizationServerId = new URL(issuer.metadata.issuer).pathname.split('/').pop();
+    let serverAudiences;
+    
+    await getAuthorizationServerInfo(config, authorizationServerId)
+    .then(res => {
+      serverAudiences = res.audiences})
+    .catch(() => {
+      throw {status: 500, error: "internal_error"};
+    });
+
+    if(!serverAudiences.includes(aud)){
+      throw {status: 400, error: "invalid_request", error_description: "Invalid aud parameter"};
+    }
+  }
+}
 
 module.exports = authorizeHandler;

--- a/oauth-proxy/package-lock.json
+++ b/oauth-proxy/package-lock.json
@@ -1259,6 +1259,11 @@
         }
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
     "clone-response": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
@@ -4258,6 +4263,14 @@
       "requires": {
         "ecdsa-sig-formatter": "^1.0.5",
         "uuid": "^3.3.2"
+      }
+    },
+    "node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "requires": {
+        "clone": "2.x"
       }
     },
     "node-fetch": {

--- a/oauth-proxy/package.json
+++ b/oauth-proxy/package.json
@@ -30,6 +30,7 @@
     "express-session": "^1.15.6",
     "jwt-decode": "^2.2.0",
     "morgan": "^1.9.1",
+    "node-cache": "^5.1.2",
     "openid-client": "^2.4.5",
     "prom-client": "^11.5.2",
     "uri-templates": "^0.2.0",

--- a/saml-proxy/src/routes/acsHandlers.ts
+++ b/saml-proxy/src/routes/acsHandlers.ts
@@ -81,7 +81,7 @@ export const loadICN = async (req: IConfiguredRequest, res: Response, next: Next
     req.user.claims.lastName = last_name;
     next();
   } catch (mviError) {
-    logger.warn("Failed MVI lookup; will try VSO search", { mviError, session, action, result: 'failure' });
+    logger.warn("Failed MVI lookup; will try VSO search", { session, action, result: 'failure' });
 
     try  {
       await requestWithMetrics(VSORequestMetrics, (): Promise<any> => {
@@ -89,7 +89,7 @@ export const loadICN = async (req: IConfiguredRequest, res: Response, next: Next
       });
       next();
     } catch (error) {
-      logger.error("Failed MVI lookup and VSO search", { error, session, action, result: 'failure' });
+      logger.error("Failed MVI lookup and VSO search", { session, action, result: 'failure' });
       res.render(unknownUsersErrorTemplate(mviError), {});
     }
   }


### PR DESCRIPTION
In accordance to FHIR specifications a check has been added to verify that third parties are sending their access tokens to the proper fhir resource. This will be done via an aud parameter in the /authorization call. The check is optional for the time being but will become mandatory after clients have been given enough time to conform to the standard.

[TestCases](https://github.com/department-of-veterans-affairs/vets-saml-proxy/files/5057996/API1741_TestCases.docx)