### PR TITLE
Updated tokenValidation to utilize v1 endpoint including aud in POST

### DIFF
--- a/oauth-proxy/cli.js
+++ b/oauth-proxy/cli.js
@@ -57,6 +57,10 @@ function processArgs() {
         required: true,
         default: "https://sandbox-api.va.gov/internal/auth/v0/validation",
       },
+      validate_post_endpoint: {
+        description: "va.gov token validation endpoint",
+        required: false,
+      },
       manage_endpoint: {
         description:
           "URL where an end-user can view which applications currently have access to data and can make adjustments to these access rights",

--- a/oauth-proxy/dev-config.base.json
+++ b/oauth-proxy/dev-config.base.json
@@ -7,6 +7,7 @@
   "dynamo_table_name": "OAuthRequests",
   "okta_url": "https://deptva-eval.okta.com",
   "validate_endpoint": "https://sandbox-api.va.gov/internal/auth/v0/validation",
+  "validate_post_endpoint": "https://sandbox-api.va.gov/internal/auth/v1/validation",
   "manage_endpoint": "https://staging.va.gov/account",
   "validate_apiKey": "<FIX ME>",
   "okta_token": "<FIX ME>",

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -470,6 +470,7 @@ function startApp(config, issuer, isolatedIssuers) {
 
   const validateToken = configureTokenValidator(
     config.validate_endpoint,
+    config.validate_post_endpoint,
     config.validate_apiKey
   );
   const app = buildApp(

--- a/oauth-proxy/oauthHandlers/tokenHandler.js
+++ b/oauth-proxy/oauthHandlers/tokenHandler.js
@@ -144,7 +144,7 @@ const tokenHandler = async (
       const validation_result = await validateToken(
         tokens.access_token,
         decoded.aud
-      );        
+      );
       const patient = validation_result.va_identifiers.icn;
       res.json({ ...tokenResponseBase, patient, state });
       return next();

--- a/oauth-proxy/oauthHandlers/tokenHandler.js
+++ b/oauth-proxy/oauthHandlers/tokenHandler.js
@@ -141,7 +141,7 @@ const tokenHandler = async (
   var decoded = jwtDecode(tokens.access_token);
   if (decoded.scp != null && decoded.scp.indexOf("launch/patient") > -1) {
     try {
-      const validation_result = await validateToken(tokens.access_token);
+      const validation_result = await validateToken(tokens.access_token, decoded.aud);
       const patient = validation_result.va_identifiers.icn;
       res.json({ ...tokenResponseBase, patient, state });
       return next();

--- a/oauth-proxy/oauthHandlers/tokenHandler.js
+++ b/oauth-proxy/oauthHandlers/tokenHandler.js
@@ -141,7 +141,9 @@ const tokenHandler = async (
   var decoded = jwtDecode(tokens.access_token);
   if (decoded.scp != null && decoded.scp.indexOf("launch/patient") > -1) {
     try {
-      const validation_result = await validateToken(tokens.access_token, decoded.aud);
+      const validation_result = await validateToken(
+        tokens.access_token,
+        decoded.aud);
       const patient = validation_result.va_identifiers.icn;
       res.json({ ...tokenResponseBase, patient, state });
       return next();

--- a/oauth-proxy/oauthHandlers/tokenHandler.js
+++ b/oauth-proxy/oauthHandlers/tokenHandler.js
@@ -143,7 +143,8 @@ const tokenHandler = async (
     try {
       const validation_result = await validateToken(
         tokens.access_token,
-        decoded.aud);
+        decoded.aud
+      );        
       const patient = validation_result.va_identifiers.icn;
       res.json({ ...tokenResponseBase, patient, state });
       return next();

--- a/oauth-proxy/tokenValidation.js
+++ b/oauth-proxy/tokenValidation.js
@@ -7,15 +7,19 @@ const axios = require("axios");
 // allowed to bubble up to the caller. You probably don't want to call this
 // directly. See configureTokenValidator below for a friendlier version.
 
-const validateToken = async (endpoint, api_key, access_token) => {
+const validateToken = async (endpoint, api_key, access_token, aud) => {
   const validateTokenStart = process.hrtime.bigint();
-  const config = {
+  const response = await axios({
+    method: 'post',
+    url: endpoint,
     headers: {
       apiKey: api_key,
       authorization: `Bearer ${access_token}`,
     },
-  };
-  const response = await axios.get(endpoint, config);
+    data: {
+      aud: aud
+    }
+  })
   stopTimer(validationGauge, validateTokenStart);
   return response.data.data.attributes;
 };
@@ -23,8 +27,8 @@ const validateToken = async (endpoint, api_key, access_token) => {
 // Returns a function that calls validateToken with the given configuration
 // parameters.
 const configureTokenValidator = (endpoint, api_key) => {
-  return (access_token) => {
-    return validateToken(endpoint, api_key, access_token);
+  return (access_token, aud) => {
+    return validateToken(endpoint, api_key, access_token, aud);
   };
 };
 

--- a/oauth-proxy/tokenValidation.js
+++ b/oauth-proxy/tokenValidation.js
@@ -7,28 +7,43 @@ const axios = require("axios");
 // allowed to bubble up to the caller. You probably don't want to call this
 // directly. See configureTokenValidator below for a friendlier version.
 
-const validateToken = async (endpoint, api_key, access_token, aud) => {
+const validateToken = async (endpoint, post_endpoint, api_key, access_token, aud) => {
   const validateTokenStart = process.hrtime.bigint();
-  const response = await axios({
-    method: "post",
-    url: endpoint,
-    headers: {
-      apiKey: api_key,
-      authorization: `Bearer ${access_token}`,
-    },
-    data: {
-      aud: aud,
-    },
-  });
-  stopTimer(validationGauge, validateTokenStart);
-  return response.data.data.attributes;
+
+  // This if/else is only required until the post validation transition
+  // is completed across all environments.
+  if (post_endpoint) {
+    const response = await axios({
+      method: "post",
+      url: post_endpoint,
+      headers: {
+        apiKey: api_key,
+        authorization: `Bearer ${access_token}`,
+      },
+      data: {
+        aud: aud,
+      },
+    });
+    stopTimer(validationGauge, validateTokenStart);
+    return response.data.data.attributes;
+  } else {
+    const config = {
+      headers: {
+        apiKey: api_key,
+        authorization: `Bearer ${access_token}`,
+      },
+    };
+    const response = await axios.get(endpoint, config);
+    stopTimer(validationGauge, validateTokenStart);
+    return response.data.data.attributes;
+  }
 };
 
 // Returns a function that calls validateToken with the given configuration
 // parameters.
-const configureTokenValidator = (endpoint, api_key) => {
+const configureTokenValidator = (endpoint, post_endpoint, api_key) => {
   return (access_token, aud) => {
-    return validateToken(endpoint, api_key, access_token, aud);
+    return validateToken(endpoint, post_endpoint, api_key, access_token, aud);
   };
 };
 

--- a/oauth-proxy/tokenValidation.js
+++ b/oauth-proxy/tokenValidation.js
@@ -10,16 +10,16 @@ const axios = require("axios");
 const validateToken = async (endpoint, api_key, access_token, aud) => {
   const validateTokenStart = process.hrtime.bigint();
   const response = await axios({
-    method: 'post',
+    method: "post",
     url: endpoint,
     headers: {
       apiKey: api_key,
       authorization: `Bearer ${access_token}`,
     },
     data: {
-      aud: aud
-    }
-  })
+      aud: aud,
+    },
+  });
   stopTimer(validationGauge, validateTokenStart);
   return response.data.data.attributes;
 };


### PR DESCRIPTION
Updated tokenValidation to utilize v1 endpoint including aud in POST

The audience value is directly supplied by Okta in the decoded token, so a simple addition to the new V1 POST endpoint is required.

Note: Corresponding devops repo config changes will be required.