### PR TITLE
API-2223 - forceAuthn undefined check

### DIFF
--- a/saml-proxy/src/routes/handlers.js
+++ b/saml-proxy/src/routes/handlers.js
@@ -40,7 +40,7 @@ export const samlLogin = function(template) {
       ].reduce((memo, [key, authnContext, exParams = null]) => {
         const params = req.sp.options.getAuthnRequestParams(
           acsUrl,
-          req.authnRequest.forceAuthn,
+          (req.authnRequest && req.authnRequest.forceAuthn) || 'false',
           (req.authnRequest && req.authnRequest.relayState) || '/',
           authnContext
         );


### PR DESCRIPTION
Add a check before referencing `forceAuthn`.

https://vajira.max.gov/browse/API-2233