### PR TITLE
API-1853: Support oauth-proxy ECS in Staging 

### DIFF
--- a/oauth-proxy/DockerfileFG
+++ b/oauth-proxy/DockerfileFG
@@ -20,4 +20,5 @@ HEALTHCHECK --interval=1m --timeout=4s --start-period=30s \
   CMD node bin/healthcheck.js
 
 USER node
+ENTRYPOINT ["/usr/local/bin/tini", "--", "/home/node/bin/config.sh"]
 CMD ["node", "index.js"]


### PR DESCRIPTION
We've added support for generating the `config.json` file required by the `oauth-proxy` app. The dockerfile for the deployment into Fargate is being updated to exercise this change.

https://vajira.max.gov/browse/API-1853

https://github.com/department-of-veterans-affairs/health-apis-docker-octopus/pull/34