### PR TITLE
API-1853: Support oauth-proxy ECS in Staging (continued)

### DIFF
--- a/oauth-proxy/DockerfileFG
+++ b/oauth-proxy/DockerfileFG
@@ -20,4 +20,5 @@ HEALTHCHECK --interval=1m --timeout=4s --start-period=30s \
   CMD node bin/healthcheck.js
 
 USER node
+ENTRYPOINT ["/usr/local/bin/tini", "--", "/home/node/bin/config.sh"]
 CMD ["node", "index.js"]

--- a/oauth-proxy/DockerfileFG
+++ b/oauth-proxy/DockerfileFG
@@ -21,4 +21,4 @@ HEALTHCHECK --interval=1m --timeout=4s --start-period=30s \
 
 USER node
 ENTRYPOINT ["/usr/local/bin/tini", "--", "/home/node/bin/config.sh"]
-CMD ["node", "index.js"]
+CMD ["node", "index.js", "--config", "/home/node/config.json"]


### PR DESCRIPTION
We've added support for generating the config.json file required by the oauth-proxy app. The dockerfile for the deployment into Fargate is being updated to exercise this change. 

- Override the command to point to the newly generated `config.json` file

https://vajira.max.gov/browse/API-1853

department-of-veterans-affairs/health-apis-docker-octopus#34