### PR TITLE
Api 1996 saml proxy linting no unused vars

### DIFF
--- a/saml-proxy/.eslintrc.yml
+++ b/saml-proxy/.eslintrc.yml
@@ -58,7 +58,11 @@ overrides:
       prettier/prettier:
         - error
       "@typescript-eslint/ban-types":
-        - warn
+        - off
+      "@typescript-eslint/explicit-module-boundary-types":
+        - off
+      "@typescript-eslint/no-explicit-any":
+        - off
       linebreak-style:
         - error
         - unix

--- a/saml-proxy/.eslintrc.yml
+++ b/saml-proxy/.eslintrc.yml
@@ -31,7 +31,7 @@ rules:
   no-dupe-keys:
     - warn
   no-unused-vars:
-    - warn
+    - error
     - { argsIgnorePattern: \b(?:res|req|next)\b }
   no-prototype-builtins:
     - off
@@ -74,5 +74,5 @@ overrides:
       no-undef:
         - warn
       "@typescript-eslint/no-unused-vars":
-        - warn
+        - error
         - { argsIgnorePattern: \b(?:res|req|next)\b }

--- a/saml-proxy/bin/healthcheck.js
+++ b/saml-proxy/bin/healthcheck.js
@@ -16,7 +16,7 @@ var request = http.request(options, (res) => {
   }
 });
 
-request.on("error", function (err) {
+request.on("error", function () {
   console.log("ERROR");
   process.exit(1);
 });

--- a/saml-proxy/loadtest/app-idp.js
+++ b/saml-proxy/loadtest/app-idp.js
@@ -3,27 +3,18 @@
 const express = require("express");
 const constants = require("../src/routes/constants");
 const handlers = require("../src/routes/handlers");
-const IdPMetadata = require("../src/idpMetadata");
 const IDPConfig = require("../src/IDPConfig").default;
 const SPConfig = require("../src/SPConfig").default;
 const cli = require("../src/cli");
 const configureHandlebars = require("../src/routes/handlebars").default;
 
-const fs = require("fs");
 const process = require("process");
-const path = require("path");
-const template = require("lodash.template");
 const samlp = require("samlp");
 const http = require("http");
-const os = require("os");
 const assignIn = require("lodash.assignin");
 const session = require("express-session");
 
-const METADATA_TEMPLATE = template(
-  fs.readFileSync(path.join(process.cwd(), "./templates/metadata.tpl"), "utf8")
-);
-
-function addRoutes(app, idpConfig, spConfig) {
+function addRoutes(app) {
   app.get(
     ["/", "/idp", constants.IDP_SSO],
     handlers.parseSamlRequest,
@@ -100,19 +91,11 @@ function runServer(argv) {
     req.idp = { options: idpConfig };
     next();
   });
-  addRoutes(app, idpConfig, spConfig);
+  addRoutes(app);
 
   console.log("starting proxy server on port %s", app.get("port"));
 
-  httpServer.listen(app.get("port"), function () {
-    const scheme = argv.idpHttps ? "https" : "http",
-      address = httpServer.address(),
-      hostname = os.hostname();
-    const baseUrl =
-      address.address === "0.0.0.0" || address.address === "::"
-        ? scheme + "://" + hostname + ":" + address.port
-        : scheme + "://localhost:" + address.port;
-  });
+  httpServer.listen(app.get("port"));
 }
 
 function main() {

--- a/saml-proxy/loadtest/app-sp.js
+++ b/saml-proxy/loadtest/app-sp.js
@@ -2,7 +2,6 @@
 
 const express = require("express");
 const constants = require("../src/routes/constants");
-const handlers = require("../src/routes/handlers");
 const IdPMetadata = require("../src/idpMetadata");
 const IDPConfig = require("../src/IDPConfig").default;
 const SPConfig = require("../src/SPConfig").default;
@@ -13,15 +12,13 @@ const fs = require("fs");
 const process = require("process");
 const path = require("path");
 const template = require("lodash.template");
-const samlp = require("samlp");
 const http = require("http");
-const os = require("os");
 
 const METADATA_TEMPLATE = template(
   fs.readFileSync(path.join(process.cwd(), "./templates/metadata.tpl"), "utf8")
 );
 
-function addRoutes(app, idpConfig, spConfig) {
+function addRoutes(app, spConfig) {
   app.get(constants.SP_METADATA_URL, function (req, res, next) {
     const xml = METADATA_TEMPLATE(spConfig.getMetadataParams(req));
     res.set("Content-Type", "text/xml");
@@ -104,19 +101,11 @@ function runServer(argv) {
         req.idp = { options: idpConfig };
         next();
       });
-      addRoutes(app, idpConfig, spConfig);
+      addRoutes(app, spConfig);
 
       console.log("starting proxy server on port %s", app.get("port"));
 
-      httpServer.listen(app.get("port"), function () {
-        const scheme = argv.idpHttps ? "https" : "http",
-          address = httpServer.address(),
-          hostname = os.hostname();
-        const baseUrl =
-          address.address === "0.0.0.0" || address.address === "::"
-            ? scheme + "://" + hostname + ":" + address.port
-            : scheme + "://localhost:" + address.port;
-      });
+      httpServer.listen(app.get("port"));
     });
 }
 

--- a/saml-proxy/src/IDMeProfileMapper.ts
+++ b/saml-proxy/src/IDMeProfileMapper.ts
@@ -214,7 +214,7 @@ export class IDMeProfileMapper implements ISamlpProfileMapper {
 
   // Returns the profile fields received from the upstream identity provider. This is part of the
   // interface required by `samlp` library.
-  public getClaims(options: object): object {
+  public getClaims(): object {
     return this.samlAssertions.claims;
   }
 
@@ -233,7 +233,7 @@ export class IDMeProfileMapper implements ISamlpProfileMapper {
     return claims;
   }
 
-  public getNameIdentifier(options: object): object {
+  public getNameIdentifier(): object {
     return {
       nameIdentifier: this.samlAssertions.userName,
       nameIdentifierFormat: this.samlAssertions.nameIdFormat,

--- a/saml-proxy/src/VetsAPIClient.test.ts
+++ b/saml-proxy/src/VetsAPIClient.test.ts
@@ -3,7 +3,7 @@ import * as request from "request-promise-native";
 import { VetsAPIClient } from "./VetsAPIClient";
 jest.mock("request-promise-native", () => {
   return {
-    post: jest.fn((_) => Promise.resolve({})),
+    post: jest.fn(() => Promise.resolve({})),
   };
 });
 
@@ -38,7 +38,7 @@ const samlTraitsICN = {
 
 beforeEach(() => {
   request.post.mockReset();
-  request.post.mockImplementation((_) =>
+  request.post.mockImplementation(() =>
     Promise.resolve({
       data: {
         id: "fakeICN",

--- a/saml-proxy/src/app.js
+++ b/saml-proxy/src/app.js
@@ -79,15 +79,7 @@ function runServer(argv) {
       });
       httpServer.keepAliveTimeout = 75000;
       httpServer.headersTimeout = 75000;
-      httpServer.listen(app.get("port"), function () {
-        const scheme = argv.idpHttps ? "https" : "http",
-          address = httpServer.address(),
-          hostname = os.hostname();
-        const baseUrl =
-          address.address === "0.0.0.0" || address.address === "::"
-            ? scheme + "://" + hostname + ":" + address.port
-            : scheme + "://localhost:" + address.port;
-      });
+      httpServer.listen(app.get("port"));
     });
 }
 

--- a/saml-proxy/src/app.js
+++ b/saml-proxy/src/app.js
@@ -5,7 +5,6 @@
 import express from "express";
 import http from "http";
 import https from "https";
-import os from "os";
 import * as IdPMetadata from "./idpMetadata";
 import * as cli from "./cli";
 import IDPConfig from "./IDPConfig";

--- a/saml-proxy/src/cli/checks.js
+++ b/saml-proxy/src/cli/checks.js
@@ -1,7 +1,6 @@
 import isString from "lodash.isstring";
-import { resolveFilePath } from "./utils";
 
-export function checkEncryptionCerts(argv, aliases) {
+export function checkEncryptionCerts(argv) {
   if (argv.idpEncryptAssertion) {
     if (argv.idpEncryptionPublicKey === undefined) {
       return "encryptionPublicKey argument is also required for assertion encryption";
@@ -13,7 +12,7 @@ export function checkEncryptionCerts(argv, aliases) {
   return true;
 }
 
-export function checkWhenNoMetadata(argv, aliases) {
+export function checkWhenNoMetadata(argv) {
   if (!isString(argv.spIdpMetaUrl)) {
     if (!isString(argv.spIdpSsoUrl) || argv.spIdpSsoUrl === "") {
       return "IdP SSO Assertion Consumer URL (spIdpSsoUrl) is required when IdP metadata is not specified";

--- a/saml-proxy/src/cli/coercing.js
+++ b/saml-proxy/src/cli/coercing.js
@@ -14,7 +14,7 @@ export function matchesCertType(value, type) {
   return cryptTypes[type] && cryptTypes[type].test(value);
 }
 
-function bufferFromString(value) {
+export function bufferFromString(value) {
   if (Buffer.hasOwnProperty("from")) {
     // node 6+
     return Buffer.from(value);
@@ -52,7 +52,7 @@ export function certToPEM(cert) {
   return cert;
 }
 
-function loadFileSync(value) {
+export function loadFileSync(value) {
   const filePath = resolveFilePath(value);
   if (filePath) {
     return fs.readFileSync(filePath, "utf8");

--- a/saml-proxy/src/cli/index.js
+++ b/saml-proxy/src/cli/index.js
@@ -7,10 +7,7 @@ import {
   loadFileSync,
   KEY_CERT_HELP_TEXT,
 } from "./coercing";
-import {
-  checkEncryptionCerts,
-  checkWhenNoMetadata,
-} from "./checks";
+import { checkEncryptionCerts, checkWhenNoMetadata } from "./checks";
 import { BINDINGS } from "../samlConstants";
 
 export function processArgs() {

--- a/saml-proxy/src/cli/index.js
+++ b/saml-proxy/src/cli/index.js
@@ -9,7 +9,6 @@ import {
 } from "./coercing";
 import {
   checkEncryptionCerts,
-  checkIdpProfileMapper,
   checkWhenNoMetadata,
 } from "./checks";
 import { BINDINGS } from "../samlConstants";
@@ -205,7 +204,7 @@ export function processArgs() {
         description: "IdP Public Key Signing Certificate (PEM)",
         required: false,
         string: true,
-        coerce: (value) => {
+        coerce: () => {
           return certToPEM(
             makeCertFileCoercer(
               "certificate",

--- a/saml-proxy/src/idpMetadata.js
+++ b/saml-proxy/src/idpMetadata.js
@@ -72,7 +72,7 @@ export function fetch(url) {
             });
 
             if (ssoEl.NameIDFormat) {
-              ssoEl.NameIDFormat.forEach((element, index, array) => {
+              ssoEl.NameIDFormat.forEach((element) => {
                 if (element._) {
                   metadata.nameIdFormats.push(element._);
                 }

--- a/saml-proxy/src/idpMetadata.js
+++ b/saml-proxy/src/idpMetadata.js
@@ -1,8 +1,7 @@
 "use strict";
 
-const util = require("util"),
-  request = require("request"),
-  xml2js = require("xml2js");
+const request = require("request");
+const xml2js = require("xml2js");
 const logger = require("./logger");
 
 function getBindingLocation(serviceEl, bindingUri) {
@@ -47,8 +46,7 @@ export function fetch(url) {
           explicitCharkey: true,
           tagNameProcessors: [xml2js.processors.stripPrefix],
         },
-        parser = new xml2js.Parser(parserConfig),
-        nameIds = [];
+        parser = new xml2js.Parser(parserConfig);
 
       parser.parseString(body, (err, docEl) => {
         if (err) {

--- a/saml-proxy/src/idpMetadata.js
+++ b/saml-proxy/src/idpMetadata.js
@@ -7,7 +7,7 @@ const logger = require("./logger");
 function getBindingLocation(serviceEl, bindingUri) {
   var location;
   if (serviceEl && serviceEl.length > 0) {
-    serviceEl.forEach((element, index, array) => {
+    serviceEl.forEach((element) => {
       if (element.$.Binding.toLowerCase() === bindingUri) {
         location = element.$.Location;
       }

--- a/saml-proxy/src/logger.ts
+++ b/saml-proxy/src/logger.ts
@@ -1,5 +1,5 @@
 import morgan, { TokenIndexer, Options } from "morgan";
-import winston, { format, createLogger, transports } from "winston";
+import { format, createLogger, transports } from "winston";
 import { Request, Response, NextFunction } from "express";
 import rTracer from "cls-rtracer";
 

--- a/saml-proxy/src/metrics.ts
+++ b/saml-proxy/src/metrics.ts
@@ -53,7 +53,7 @@ export const MVIRequestMetrics = {
 export const VSORequestMetrics = {
   histogram: VSOLookupBucket,
   attempt: VSOAttempt,
-  failure: MVIFailure,
+  failure: VSOFailure,
 };
 
 export interface IRequestMetrics {

--- a/saml-proxy/src/routes/acsHandlers.test.ts
+++ b/saml-proxy/src/routes/acsHandlers.test.ts
@@ -1,5 +1,4 @@
 import "jest";
-import { Response, Request, NextFunction } from "express";
 
 import * as handlers from "./acsHandlers";
 import { VetsAPIClient } from "../VetsAPIClient";
@@ -219,7 +218,7 @@ describe("requestWithMetrics", () => {
   it("should call the passed in functions promise", async () => {
     let called = false;
     const func = () => {
-      return new Promise((resolve, _) => {
+      return new Promise((resolve) => {
         called = true;
         resolve();
       });

--- a/saml-proxy/src/routes/acsHandlers.ts
+++ b/saml-proxy/src/routes/acsHandlers.ts
@@ -1,4 +1,4 @@
-import { IDP_SSO, SP_VERIFY, SP_LOGIN_URL } from "./constants";
+import { SP_VERIFY, SP_LOGIN_URL } from "./constants";
 import { getReqUrl, logRelayState } from "../utils";
 import { IConfiguredRequest } from "./types";
 
@@ -26,7 +26,7 @@ const unknownUsersErrorTemplate = (error: any) => {
   }
 };
 
-export const urlUserErrorTemplate = (error: any) => {
+export const urlUserErrorTemplate = () => {
   // `error` comes from:
   // https://github.com/request/promise-core/blob/master/lib/errors.js
   return "handleFailure.hbs";

--- a/saml-proxy/src/routes/handlebars.js
+++ b/saml-proxy/src/routes/handlebars.js
@@ -45,10 +45,7 @@ export default function configureHandlebars() {
   // Given a string like "1-777-888-9999" it generates an anchor tag like so:
   //
   //   <a href="tel:17778889999" aria-label="1. 7 7 7. 8 8 8. 9 9 9 9.">1-777-888-9999</a>
-  hbs.registerHelper("accessible-phone-number", function (
-    digitString,
-    context
-  ) {
+  hbs.registerHelper("accessible-phone-number", function (digitString) {
     var digits = digitString.split("").filter(function (ch) {
       return "0123456789".indexOf(ch) !== -1;
     });

--- a/saml-proxy/src/routes/handlers.js
+++ b/saml-proxy/src/routes/handlers.js
@@ -177,8 +177,6 @@ export const acsFactory = (app, acsUrl) => {
   app.post(getPath(acsUrl), processAcs(acsUrl));
 };
 
-const setUpSaml = function (req, res, view) {};
-
 export const handleError = (req, res) => {
   logger.error({ idp_sid: req.cookies.idp_sid });
   res.render(urlUserErrorTemplate(req, {}));

--- a/saml-proxy/src/routes/index.js
+++ b/saml-proxy/src/routes/index.js
@@ -160,7 +160,7 @@ export default function configureExpress(
 
   app.use(function (req, res, next) {
     if (req.idp.options.rollSession) {
-      req.session.regenerate(function (err) {
+      req.session.regenerate(function () {
         return next();
       });
     } else {

--- a/saml-proxy/src/routes/routes.js
+++ b/saml-proxy/src/routes/routes.js
@@ -1,7 +1,6 @@
 import {
   IDP_SSO,
   IDP_METADATA,
-  IDP_REDIRECT,
   SP_METADATA_URL,
   SP_VERIFY,
   SP_ERROR_URL,
@@ -11,7 +10,6 @@ import {
 import {
   acsFactory,
   parseSamlRequest,
-  showLoginOptions,
   handleError,
   samlLogin,
   idpSignIn,

--- a/saml-proxy/test/e2e.test.js
+++ b/saml-proxy/test/e2e.test.js
@@ -34,7 +34,7 @@ const vetsApiClient = new MockVetsApiClient();
 
 function buildSamlResponse(type, level_of_assurance) {
   const user = getUser(type, level_of_assurance);
-  return new Promise((resolve, _) => {
+  return new Promise((resolve) => {
     getSamlResponse(idpConfig, user, (_, samlResponse) => {
       resolve(btoa(samlResponse));
     });

--- a/saml-proxy/test/mockVetsApiClient.ts
+++ b/saml-proxy/test/mockVetsApiClient.ts
@@ -1,35 +1,6 @@
-import { SAMLUser } from "../src/VetsAPIClient";
-
 export default class MockVetsApiClient {
   public findUserInMVI = true;
   public userIsVSO = true;
-
-  public async getMVITraitsForLoa3User(
-    user: SAMLUser
-  ): Promise<{ icn: string; first_name: string; last_name: string }> {
-    if (this.findUserInMVI) {
-      return {
-        icn: "123",
-        first_name: user.firstName,
-        last_name: user.lastName,
-      };
-    }
-
-    throw new Error("Not found");
-  }
-
-  public async getVSOSearch(
-    firstName: string, // eslint-disable-line
-    lastName: string // eslint-disable-line
-  ): Promise<{ poa: string }> {
-    if (this.userIsVSO) {
-      return {
-        poa: "poa",
-      };
-    }
-
-    throw new Error("Not found");
-  }
 
   public reset() {
     this.findUserInMVI = true;

--- a/saml-proxy/test/mockVetsApiClient.ts
+++ b/saml-proxy/test/mockVetsApiClient.ts
@@ -19,8 +19,8 @@ export default class MockVetsApiClient {
   }
 
   public async getVSOSearch(
-    firstName: string,
-    lastName: string
+    firstName: string, // eslint-disable-line
+    lastName: string // eslint-disable-line
   ): Promise<{ poa: string }> {
     if (this.userIsVSO) {
       return {

--- a/saml-proxy/test/mockVetsApiClient.ts
+++ b/saml-proxy/test/mockVetsApiClient.ts
@@ -1,6 +1,40 @@
+import { SAMLUser } from "../src/VetsAPIClient";
+
 export default class MockVetsApiClient {
   public findUserInMVI = true;
   public userIsVSO = true;
+
+  public async getMVITraitsForLoa3User(
+    user: SAMLUser
+  ): Promise<{ icn: string; first_name: string; last_name: string }> {
+    if (this.findUserInMVI) {
+      return {
+        icn: "123",
+        first_name: user.firstName,
+        last_name: user.lastName,
+      };
+    }
+
+    throw new Error("Not found");
+  }
+
+  /*
+   * Mock VSO search.
+   *
+   * Params are unused but are present to mimic real signature.
+   */
+  public async getVSOSearch(
+    firstName: string, // eslint-disable-line
+    lastName: string // eslint-disable-line
+  ): Promise<{ poa: string }> {
+    if (this.userIsVSO) {
+      return {
+        poa: "poa",
+      };
+    }
+
+    throw new Error("Not found");
+  }
 
   public reset() {
     this.findUserInMVI = true;


### PR DESCRIPTION
Added no-unused-vars linting rules to saml-proxy.

[regression tests](https://github.com/department-of-veterans-affairs/vets-saml-proxy/files/5178575/API1996_RegressionTestsNoUnusedVars.docx)
