### PR TITLE
API-2338-font-404-fix Fixing font 404's by updating route in express …

### DIFF
--- a/saml-proxy/src/routes/index.js
+++ b/saml-proxy/src/routes/index.js
@@ -145,6 +145,7 @@ export default function configureExpress(
   );
 
   app.use("/samlproxy/idp", express.static(path.join(process.cwd(), "public")));
+  app.use("/fonts", express.static(path.join(process.cwd(), "public/fonts")));
   app.use(
     "/samlproxy/assets/fonts",
     express.static(path.join(process.cwd(), "public/fonts"))

--- a/saml-proxy/src/routes/index.js
+++ b/saml-proxy/src/routes/index.js
@@ -145,7 +145,10 @@ export default function configureExpress(
   );
 
   app.use("/samlproxy/idp", express.static(path.join(process.cwd(), "public")));
-  app.use("/fonts", express.static(path.join(process.cwd(), "public/fonts")));
+  app.use(
+    "/samlproxy/assets/fonts",
+    express.static(path.join(process.cwd(), "public/fonts"))
+  );
 
   app.use(function (req, res, next) {
     req.metadata = idpOptions.profileMapper.metadata;


### PR DESCRIPTION

Fixing font 404's by adding a new route in the express middleware so that requests looking for fonts at samlproxy/assets/fonts will be directed to the public/fonts directory.