### PR TITLE
Api 2237 error page displays request

### DIFF
--- a/saml-proxy/src/routes/index.js
+++ b/saml-proxy/src/routes/index.js
@@ -206,6 +206,7 @@ export default function configureExpress(
         res.statusCode < 500 ? err.message : "Error processing SAML request";
       res.render("error", {
         message: errMessage,
+        request_id: rTracer.id(),
       });
     }
   });

--- a/saml-proxy/views/error.hbs
+++ b/saml-proxy/views/error.hbs
@@ -2,6 +2,8 @@
 	<h1>{{message}}</h1>
 	<h2>{{error.status}}</h1>
 	<pre>{{error.stack}}</pre>
+  <h2>Error ID</h2>
+  <pre>{{request_id}}</pre>
   <div class="col-md-12 text-right">
     <form action="/" method="get">
       <button id="btn-return" class="btn btn-primary input-xlarge" type="submit"><i class="fa fa-home"><span>Restart</span></i></button>

--- a/saml-proxy/views/error.hbs
+++ b/saml-proxy/views/error.hbs
@@ -1,5 +1,5 @@
 <div id="container">
-	<h1>{{message}}</h1>
+  <h1>{{message}}</h1>
   <h2>Error ID</h2>
   <pre>{{request_id}}</pre>
   <div class="col-md-12 text-right">

--- a/saml-proxy/views/error.hbs
+++ b/saml-proxy/views/error.hbs
@@ -1,7 +1,5 @@
 <div id="container">
 	<h1>{{message}}</h1>
-	<h2>{{error.status}}</h1>
-	<pre>{{error.stack}}</pre>
   <h2>Error ID</h2>
   <pre>{{request_id}}</pre>
   <div class="col-md-12 text-right">


### PR DESCRIPTION
Added request id to error pages, so user errors can be easily traced.

[API-2237-Regression-Testing.docx](https://github.com/department-of-veterans-affairs/vets-saml-proxy/files/5307787/API-2237-Regression-Testing.docx)
