### PR TITLE
Api 1996 make no undef and no dupe keys errors

### DIFF
--- a/saml-proxy/.eslintrc.yml
+++ b/saml-proxy/.eslintrc.yml
@@ -26,8 +26,6 @@ rules:
   semi:
     - error
     - always
-  no-undef:
-    - warn
   no-dupe-keys:
     - warn
   no-unused-vars:
@@ -75,8 +73,6 @@ overrides:
         - always
       no-prototype-builtins:
         - off
-      no-undef:
-        - warn
       "@typescript-eslint/no-unused-vars":
         - error
         - { argsIgnorePattern: \b(?:res|req|next)\b }

--- a/saml-proxy/.eslintrc.yml
+++ b/saml-proxy/.eslintrc.yml
@@ -26,8 +26,6 @@ rules:
   semi:
     - error
     - always
-  no-dupe-keys:
-    - warn
   no-unused-vars:
     - error
     - { argsIgnorePattern: \b(?:res|req|next)\b }

--- a/saml-proxy/loadtest/app-idp.js
+++ b/saml-proxy/loadtest/app-idp.js
@@ -11,6 +11,7 @@ const configureHandlebars = require("../src/routes/handlebars").default;
 const process = require("process");
 const samlp = require("samlp");
 const http = require("http");
+const https = require("https");
 const assignIn = require("lodash.assignin");
 const session = require("express-session");
 

--- a/saml-proxy/loadtest/app-sp.js
+++ b/saml-proxy/loadtest/app-sp.js
@@ -13,6 +13,7 @@ const process = require("process");
 const path = require("path");
 const template = require("lodash.template");
 const http = require("http");
+const https = require("https");
 
 const METADATA_TEMPLATE = template(
   fs.readFileSync(path.join(process.cwd(), "./templates/metadata.tpl"), "utf8")

--- a/saml-proxy/package-lock.json
+++ b/saml-proxy/package-lock.json
@@ -2268,6 +2268,11 @@
         "node-int64": "^0.4.0"
       }
     },
+    "btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
+    },
     "buffer": {
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
@@ -4427,7 +4432,7 @@
     },
     "foundation-sites": {
       "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/foundation-sites/-/foundation-sites-5.5.3.tgz",
+      "resolved": "http://registry.npmjs.org/foundation-sites/-/foundation-sites-5.5.3.tgz",
       "integrity": "sha1-ZVbrKzHN47ImYwEWvSFdldBWwKc="
     },
     "fragment-cache": {
@@ -4924,7 +4929,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",

--- a/saml-proxy/package.json
+++ b/saml-proxy/package.json
@@ -68,6 +68,7 @@
     "@types/request-promise-native": "^1.0.15",
     "acorn": "^7.4.0",
     "body-parser": "~1.18.3",
+    "btoa": "^1.2.1",
     "cls-rtracer": "^2.3.0",
     "connect-flash": "^0.1.1",
     "cookie-parser": "~1.4.3",

--- a/saml-proxy/src/cli/checks.js
+++ b/saml-proxy/src/cli/checks.js
@@ -1,4 +1,5 @@
 import isString from "lodash.isstring";
+import { certToPEM } from "../src/cli/coercing";
 
 export function checkEncryptionCerts(argv) {
   if (argv.idpEncryptAssertion) {

--- a/saml-proxy/src/cli/checks.js
+++ b/saml-proxy/src/cli/checks.js
@@ -1,5 +1,5 @@
 import isString from "lodash.isstring";
-import { certToPEM } from "../src/cli/coercing";
+import { certToPEM } from "./coercing";
 
 export function checkEncryptionCerts(argv) {
   if (argv.idpEncryptAssertion) {

--- a/saml-proxy/test/e2e.test.js
+++ b/saml-proxy/test/e2e.test.js
@@ -8,6 +8,8 @@ import { buildBackgroundServerModule } from "../../common/backgroundServer";
 import { getTestExpressApp, idpConfig } from "./testServer";
 import { MHV_USER, DSLOGON_USER, IDME_USER, getUser } from "./testUsers";
 import MockVetsApiClient from "./mockVetsApiClient";
+import atob from "atob";
+import btoa from "btoa";
 
 const {
   startServerInBackground,

--- a/saml-proxy/test/testServer.js
+++ b/saml-proxy/test/testServer.js
@@ -34,8 +34,6 @@ const defaultTestingConfig = {
   spValidateNameIDFormat: true,
   spNameIDFormat: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
   spRequestAuthnContext: true,
-  spAuthnContextClassRef:
-    "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
 };
 
 export const idpConfig = new IDPConfig(defaultTestingConfig);

--- a/saml-proxy/test/testServer.js
+++ b/saml-proxy/test/testServer.js
@@ -15,7 +15,6 @@ const defaultTestingConfig = {
   idpBaseUrl: "https://dev-api.va.gov/samlproxy/idp",
   spIdpMetaUrl: "https://api.idmelabs.com/saml/metadata/provider",
   spIdpSsoBinding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-  spNameIDFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
   spProtocol: "samlp",
   spIdpSsoUrl: "https://api.idmelabs.com/saml/SingleSignOnService",
   spAudience: "test",


### PR DESCRIPTION
Final linting fixes to saml-proxy.

[regression tests](https://github.com/department-of-veterans-affairs/vets-saml-proxy/files/5343022/API1996_saml_proxy_regression_testing.docx)
