### PR TITLE
API-2333 - OIDC timeouts

### DIFF
--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -57,7 +57,6 @@ async function createIssuer(upstream_issuer, upstream_issuer_timeout_ms) {
       options.timeout = upstream_issuer_timeout_ms;
       return options;
     };
-
   }
   return await Issuer.discover(upstream_issuer);
 }

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const cors = require("cors");
-const { Issuer } = require("openid-client");
+const { Issuer, custom } = require("openid-client");
 const process = require("process");
 const bodyParser = require("body-parser");
 const dynamoClient = require("./dynamo_client");
@@ -53,7 +53,11 @@ const openidMetadataWhitelist = [
 
 async function createIssuer(upstream_issuer, upstream_issuer_timeout_ms) {
   if (upstream_issuer_timeout_ms) {
-    Issuer.defaultHttpOptions = { timeout: upstream_issuer_timeout_ms };
+    Issuer[custom.http_options] = function (options) {
+      options.timeout = upstream_issuer_timeout_ms;
+      return options;
+    };
+
   }
   return await Issuer.discover(upstream_issuer);
 }


### PR DESCRIPTION
Setting a custom timeout changed with v 3.0.0 of oidc-client (https://github.com/panva/node-openid-client/tree/v3.15.10/docs#customizing).

Verified timeout is applied by setting it to a low value (400ms) and seeing that a refresh token request occasionally times-out at the given limit.

https://vajira.max.gov/browse/API-3222