### PR TITLE
API-1852: Support saml-proxy ECS in Staging

### DIFF
--- a/saml-proxy/DockerfileFG
+++ b/saml-proxy/DockerfileFG
@@ -20,7 +20,9 @@ RUN ./node_modules/.bin/tsc
 HEALTHCHECK --interval=1m --timeout=4s --start-period=30s \
   CMD node bin/healthcheck.js
 
-RUN chown -R node:node /home/node 
+RUN chown -R node:node /home/node
 
 USER node
-CMD ["node", "build/app.js"]
+ENTRYPOINT ["/usr/local/bin/tini", "--", "/home/node/bin/config.sh"]
+
+CMD ["node", "build/app.js", "--config", "/home/node/config.json"]


### PR DESCRIPTION
We've added support for generating the config.json file required by the saml-proxy app. The dockerfile for the deployment into Fargate is being updated to exercise this change.

https://vajira.max.gov/browse/API-1852

Related: #140 