### PR TITLE
Api 3015 oauth proxy client credentials flow

### DIFF
--- a/oauth-proxy/oauthHandlers/tokenHandler.js
+++ b/oauth-proxy/oauthHandlers/tokenHandler.js
@@ -151,7 +151,7 @@ const getTokenStrategy = (
     ) {
       throw {
         status: 400,
-        error: "Client assertion error",
+        error: "invalid_request",
         error_description: "Client assertion type must be jwt-bearer.",
       };
     }

--- a/oauth-proxy/oauthHandlers/tokenHandler.js
+++ b/oauth-proxy/oauthHandlers/tokenHandler.js
@@ -6,6 +6,9 @@ const {
   AuthorizationCodeStrategy,
 } = require("./tokenHandlerStrategyClasses/authorizationCodeStrategy");
 const {
+  ClientCredentialsStrategy,
+} = require("./tokenHandlerStrategyClasses/clientCredentialsStrategy");
+const {
   UnsupportedGrantStrategy,
 } = require("./tokenHandlerStrategyClasses/unsupportedGrantStrategy");
 const {
@@ -86,6 +89,8 @@ function createClientMetadata(redirect_uri, req, config) {
     clientMetadata.token_endpoint_auth_method = "none";
     clientMetadata.client_id = req.body.client_id;
     delete req.body.client_id;
+  } else if (req.body.grant_type === "client_credentials") {
+    //Unused by client credentials flow
   } else {
     throw {
       error: "invalid_client",
@@ -136,6 +141,14 @@ const getTokenStrategy = (
       dynamoClient,
       redirect_uri,
       getClient(issuer, redirect_uri, req, config)
+    );
+  } else if (req.body.grant_type === "client_credentials") {
+    tokenHandlerStrategy = new ClientCredentialsStrategy(
+      req,
+      logger,
+      dynamo,
+      dynamoClient,
+      issuer.token_endpoint
     );
   } else {
     tokenHandlerStrategy = new UnsupportedGrantStrategy();

--- a/oauth-proxy/oauthHandlers/tokenHandler.js
+++ b/oauth-proxy/oauthHandlers/tokenHandler.js
@@ -90,8 +90,6 @@ function createClientMetadata(redirect_uri, req, config) {
     clientMetadata.token_endpoint_auth_method = "none";
     clientMetadata.client_id = req.body.client_id;
     delete req.body.client_id;
-  } else if (req.body.grant_type === "client_credentials") {
-    //Unused by client credentials flow
   } else {
     throw {
       error: "invalid_client",

--- a/oauth-proxy/oauthHandlers/tokenHandler.js
+++ b/oauth-proxy/oauthHandlers/tokenHandler.js
@@ -145,6 +145,13 @@ const getTokenStrategy = (
       validateToken
     );
   } else if (req.body.grant_type === "client_credentials") {
+    if (req.body.client_assertion_type !== "urn:ietf:params:oauth:client-assertion-type:jwt-bearer") {
+      throw {
+        status: 400,
+        error: "Client assertion error",
+        error_description: "Client assertion type must be jwt-bearer.",
+      };
+    }
     tokenHandlerStrategy = new ClientCredentialsStrategy(
       req,
       logger,

--- a/oauth-proxy/oauthHandlers/tokenHandler.js
+++ b/oauth-proxy/oauthHandlers/tokenHandler.js
@@ -36,7 +36,8 @@ const tokenHandler = async (
       dynamo,
       dynamoClient,
       config,
-      req
+      req,
+      validateToken
     );
   } catch (error) {
     rethrowIfRuntimeError(error);
@@ -122,7 +123,8 @@ const getTokenStrategy = (
   dynamo,
   dynamoClient,
   config,
-  req
+  req,
+  validateToken
 ) => {
   let tokenHandlerStrategy;
   if (req.body.grant_type === "refresh_token") {
@@ -131,7 +133,8 @@ const getTokenStrategy = (
       logger,
       dynamo,
       dynamoClient,
-      getClient(issuer, redirect_uri, req, config)
+      getClient(issuer, redirect_uri, req, config),
+      validateToken
     );
   } else if (req.body.grant_type === "authorization_code") {
     tokenHandlerStrategy = new AuthorizationCodeStrategy(
@@ -140,7 +143,8 @@ const getTokenStrategy = (
       dynamo,
       dynamoClient,
       redirect_uri,
-      getClient(issuer, redirect_uri, req, config)
+      getClient(issuer, redirect_uri, req, config),
+      validateToken
     );
   } else if (req.body.grant_type === "client_credentials") {
     tokenHandlerStrategy = new ClientCredentialsStrategy(

--- a/oauth-proxy/oauthHandlers/tokenHandler.js
+++ b/oauth-proxy/oauthHandlers/tokenHandler.js
@@ -145,7 +145,10 @@ const getTokenStrategy = (
       validateToken
     );
   } else if (req.body.grant_type === "client_credentials") {
-    if (req.body.client_assertion_type !== "urn:ietf:params:oauth:client-assertion-type:jwt-bearer") {
+    if (
+      req.body.client_assertion_type !==
+      "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+    ) {
       throw {
         status: 400,
         error: "Client assertion error",

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/authorizationCodeStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/authorizationCodeStrategy.js
@@ -1,7 +1,15 @@
 const { rethrowIfRuntimeError, statusCodeFromError } = require("../../utils");
 
 class AuthorizationCodeStrategy {
-  constructor(req, logger, dynamo, dynamoClient, redirect_uri, client, validateToken) {
+  constructor(
+    req,
+    logger,
+    dynamo,
+    dynamoClient,
+    redirect_uri,
+    client,
+    validateToken
+  ) {
     this.req = req;
     this.logger = logger;
     this.dynamo = dynamo;

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
@@ -53,18 +53,16 @@ class ClientCredentialsStrategy {
   }
 
   async pullDocumentFromDynamo() {
-    //Unused
+    //Currently unused, follow on to pull & store launch context
   }
 
   async saveDocumentToDynamo(document, tokens) {
-    //Unused
+    //Currently unused, follow on to pull & store launch context
   }
 
   async createPatientInfo(tokens, decoded) {
-    console.log("createPatientInfo");
-    console.log(decoded);
-    return '123V123';
-    //return decoded.launch;
+    //TODO: some validation on the request body would be good here
+    return this.req.body.launch;
   }
 
 }

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
@@ -10,7 +10,6 @@ class ClientCredentialsStrategy {
     this.token_endpoint = token_endpoint;
   }
 
-  //will throw error if cannot retrieve refresh token
   async getTokenResponse() {
     let token;
     let res;

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
@@ -27,6 +27,9 @@ class ClientCredentialsStrategy {
       if (res.status == 200) {
         token = res.data;
       } else {
+        this.logger.error({
+          message: "Server returned status code " + res.status,
+        });
         throw {
           statusCode: 500,
           error: "token_failure",

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
@@ -29,22 +29,32 @@ class ClientCredentialsStrategy {
       if (res.status == 200) {
         token = res.data;
       } else {
-        //TODO: confirm appropriate error
         throw {
-          status: 500,
+          statusCode: 500,
           error: "token_failure",
           error_description: "Failed to retrieve access_token.",
         };
       }
     } catch (error) {
-      rethrowIfRuntimeError(error);
-      return {
-        statusCode: error.statusCode,
-        responseBody: {
-          error: error.error,
-          error_description: error.error_description,
-        },
-      };
+      if (error.response.status == 400) {
+        throw {
+          statusCode: 400,
+          error: error.response.data.errorCode,
+          error_description: error.response.data.errorSummary,
+        };
+      } else if (error.response.status == 401) {
+        throw {
+          statusCode: 401,
+          error: error.response.data.error,
+          error_description: error.response.data.error_description,
+        };
+      } else {
+        throw {
+          statusCode: 500,
+          error: "token_failure",
+          error_description: "Failed to retrieve access_token.",
+        };
+      }
     }
 
     return token;

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
@@ -35,11 +35,19 @@ class ClientCredentialsStrategy {
       }
     } catch (error) {
       if (error.response.status == 400) {
-        throw {
-          statusCode: 400,
-          error: error.response.data.errorCode,
-          error_description: error.response.data.errorSummary,
-        };
+        if (error.response.data.errorCode) {
+          throw {
+            statusCode: 400,
+            error: error.response.data.errorCode,
+            error_description: error.response.data.errorSummary,
+          };
+        } else {
+          throw {
+            statusCode: 400,
+            error: error.response.data.error,
+            error_description: error.response.data.error_description,
+          };
+        }
       } else if (error.response.status == 401) {
         throw {
           statusCode: 401,

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
@@ -1,0 +1,72 @@
+const process = require("process");
+const axios = require("axios");
+const qs = require('qs');
+
+const { rethrowIfRuntimeError, statusCodeFromError } = require("../../utils");
+const { oktaTokenRefreshGauge, stopTimer } = require("../../metrics");
+
+class ClientCredentialsStrategy {
+  constructor(req, logger, dynamo, dynamoClient, token_endpoint) {
+    this.req = req;
+    this.logger = logger;
+    this.dynamo = dynamo;
+    this.dynamoClient = dynamoClient;
+    this.token_endpoint = token_endpoint;
+  }
+
+  //will throw error if cannot retrieve refresh token
+  async getTokenResponse() {
+    let token;
+    let res;
+
+    delete this.req.headers.host;
+    var data = qs.stringify(this.req.body);
+    try {
+      res = await axios({
+        method: 'post',
+        url: this.token_endpoint,
+        data: data,
+        headers: this.req.headers
+      });
+      if (res.status == 200) {
+        token = res.data;
+      } else {
+        //TODO: confirm appropriate error
+        throw {
+          status: 500,
+          error: "token_failure",
+          error_description: "Failed to retrieve access_token.",
+        };
+      }
+    } catch (error) {
+      rethrowIfRuntimeError(error);
+      return {
+        statusCode: error.statusCode,
+        responseBody: {
+          error: error.error,
+          error_description: error.error_description,
+        },
+      };
+    }
+
+    return token;
+  }
+
+  async pullDocumentFromDynamo() {
+    //Unused
+  }
+
+  async saveDocumentToDynamo(document, tokens) {
+    //Unused
+  }
+
+  async createPatientInfo(tokens, decoded) {
+    console.log("createPatientInfo");
+    console.log(decoded);
+    return '123V123';
+    //return decoded.launch;
+  }
+
+}
+
+module.exports = { ClientCredentialsStrategy };

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
@@ -1,8 +1,6 @@
 const axios = require("axios");
 const qs = require("qs");
 
-const { rethrowIfRuntimeError } = require("../../utils");
-
 class ClientCredentialsStrategy {
   constructor(req, logger, dynamo, dynamoClient, token_endpoint) {
     this.req = req;

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
@@ -76,7 +76,7 @@ class ClientCredentialsStrategy {
 
   // eslint-disable-next-line no-unused-vars
   async createPatientInfo(tokens, decoded) {
-    //TODO: some validation on the request body would be good here
+    //Consider some validation on the request body here
     return this.req.body.launch;
   }
 }

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
@@ -1,5 +1,6 @@
 const axios = require("axios");
 const qs = require("qs");
+const { rethrowIfRuntimeError } = require("../../utils");
 
 class ClientCredentialsStrategy {
   constructor(req, logger, dynamo, dynamoClient, token_endpoint) {
@@ -54,6 +55,14 @@ class ClientCredentialsStrategy {
           error_description: error.response.data.error_description,
         };
       } else {
+        rethrowIfRuntimeError(error);
+        if (error.response) {
+          this.logger.error({
+            message: "Server returned status code " + error.response.status,
+          });
+        } else {
+          this.logger.error({ message: error.message });
+        }
         throw {
           statusCode: 500,
           error: "token_failure",

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
@@ -34,6 +34,7 @@ class ClientCredentialsStrategy {
         };
       }
     } catch (error) {
+      rethrowIfRuntimeError(error);
       if (error.response.status == 400) {
         if (error.response.data.errorCode) {
           throw {
@@ -55,7 +56,6 @@ class ClientCredentialsStrategy {
           error_description: error.response.data.error_description,
         };
       } else {
-        rethrowIfRuntimeError(error);
         if (error.response) {
           this.logger.error({
             message: "Server returned status code " + error.response.status,

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy.js
@@ -1,9 +1,7 @@
-const process = require("process");
 const axios = require("axios");
-const qs = require('qs');
+const qs = require("qs");
 
-const { rethrowIfRuntimeError, statusCodeFromError } = require("../../utils");
-const { oktaTokenRefreshGauge, stopTimer } = require("../../metrics");
+const { rethrowIfRuntimeError } = require("../../utils");
 
 class ClientCredentialsStrategy {
   constructor(req, logger, dynamo, dynamoClient, token_endpoint) {
@@ -23,10 +21,10 @@ class ClientCredentialsStrategy {
     var data = qs.stringify(this.req.body);
     try {
       res = await axios({
-        method: 'post',
+        method: "post",
         url: this.token_endpoint,
         data: data,
-        headers: this.req.headers
+        headers: this.req.headers,
       });
       if (res.status == 200) {
         token = res.data;
@@ -56,15 +54,16 @@ class ClientCredentialsStrategy {
     //Currently unused, follow on to pull & store launch context
   }
 
+  // eslint-disable-next-line no-unused-vars
   async saveDocumentToDynamo(document, tokens) {
     //Currently unused, follow on to pull & store launch context
   }
 
+  // eslint-disable-next-line no-unused-vars
   async createPatientInfo(tokens, decoded) {
     //TODO: some validation on the request body would be good here
     return this.req.body.launch;
   }
-
 }
 
 module.exports = { ClientCredentialsStrategy };

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/refreshTokenStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/refreshTokenStrategy.js
@@ -3,12 +3,13 @@ const { rethrowIfRuntimeError, statusCodeFromError } = require("../../utils");
 const { oktaTokenRefreshGauge, stopTimer } = require("../../metrics");
 
 class RefreshTokenStrategy {
-  constructor(req, logger, dynamo, dynamoClient, client) {
+  constructor(req, logger, dynamo, dynamoClient, client, validateToken) {
     this.req = req;
     this.logger = logger;
     this.dynamo = dynamo;
     this.dynamoClient = dynamoClient;
     this.client = client;
+    this.validateToken = validateToken;
   }
 
   //will throw error if cannot retrieve refresh token
@@ -66,6 +67,27 @@ class RefreshTokenStrategy {
         error
       );
     }
+  }
+
+  async createPatientInfo(tokens, decoded) {
+    let patient;
+    try {
+      const validation_result = await this.validateToken(
+        tokens.access_token,
+        decoded.aud
+      );
+      patient = validation_result.va_identifiers.icn;
+    } catch (error) {
+      rethrowIfRuntimeError(error);
+      let returnError = {
+        error: "invalid_grant",
+        error_description:
+          "Could not find a valid patient identifier for the provided authorization code.",
+      };
+      this.logger.error(returnError.error_description, error);
+      throw returnError;
+    }
+    return patient;
   }
 }
 

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClient.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClient.js
@@ -55,7 +55,10 @@ class TokenHandlerClient {
     const tokenResponseBase = translateTokenSet(tokens);
     let decoded = jwtDecode(tokens.access_token);
     if (decoded.scp != null && decoded.scp.indexOf("launch/patient") > -1) {
-      let patient = await this.tokenHandlerStrategy.createPatientInfo(tokens, decoded);
+      let patient = await this.tokenHandlerStrategy.createPatientInfo(
+        tokens,
+        decoded
+      );
       return {
         statusCode: 200,
         responseBody: { ...tokenResponseBase, patient, state },
@@ -63,7 +66,6 @@ class TokenHandlerClient {
     }
     return { statusCode: 200, responseBody: { ...tokenResponseBase, state } };
   }
-  
 }
 
 module.exports = { TokenHandlerClient };

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClient.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClient.js
@@ -55,7 +55,7 @@ class TokenHandlerClient {
     const tokenResponseBase = translateTokenSet(tokens);
     let decoded = jwtDecode(tokens.access_token);
     if (decoded.scp != null && decoded.scp.indexOf("launch/patient") > -1) {
-      let patient = await this.createPatientInfo(tokens, decoded);
+      let patient = await this.tokenHandlerStrategy.createPatientInfo(tokens, decoded);
       return {
         statusCode: 200,
         responseBody: { ...tokenResponseBase, patient, state },
@@ -63,27 +63,7 @@ class TokenHandlerClient {
     }
     return { statusCode: 200, responseBody: { ...tokenResponseBase, state } };
   }
-
-  async createPatientInfo(tokens, decoded) {
-    let patient;
-    try {
-      const validation_result = await this.validateToken(
-        tokens.access_token,
-        decoded.aud
-      );
-      patient = validation_result.va_identifiers.icn;
-    } catch (error) {
-      rethrowIfRuntimeError(error);
-      let returnError = {
-        error: "invalid_grant",
-        error_description:
-          "Could not find a valid patient identifier for the provided authorization code.",
-      };
-      this.logger.error(returnError.error_description, error);
-      throw returnError;
-    }
-    return patient;
-  }
+  
 }
 
 module.exports = { TokenHandlerClient };

--- a/oauth-proxy/package.json
+++ b/oauth-proxy/package.json
@@ -66,6 +66,7 @@
     "yargs": "^15.3.1"
   },
   "devDependencies": {
+    "axios-mock-adapter": "^1.19.0",
     "babel-eslint": "^10.1.0",
     "crypto": "^1.0.1",
     "eslint": "^7.6.0",

--- a/oauth-proxy/package.json
+++ b/oauth-proxy/package.json
@@ -21,7 +21,7 @@
     ],
     "coverageThreshold": {
       "global": {
-        "lines": 78
+        "lines": 77
       }
     },
     "testPathIgnorePatterns": [

--- a/oauth-proxy/package.json
+++ b/oauth-proxy/package.json
@@ -21,7 +21,7 @@
     ],
     "coverageThreshold": {
       "global": {
-        "lines": 77
+        "lines": 78
       }
     },
     "testPathIgnorePatterns": [

--- a/oauth-proxy/tests/clientCredentialsStrategy.test.js
+++ b/oauth-proxy/tests/clientCredentialsStrategy.test.js
@@ -1,0 +1,126 @@
+require("jest");
+const axios = require("axios");
+const MockAdapter = require("axios-mock-adapter");
+const MockExpressRequest = require("mock-express-request");
+const { buildFakeDynamoClient } = require("./testUtils");
+const {
+  ClientCredentialsStrategy,
+} = require("../oauthHandlers/tokenHandlerStrategyClasses/clientCredentialsStrategy");
+
+let logger;
+let dynamo;
+let dynamoClient;
+let token_endpoint = "http://localhost:9090/testServer/token";
+let mock = new MockAdapter(axios);
+
+beforeEach(() => {
+  logger = { error: jest.fn(), info: jest.fn(), warn: jest.fn() };
+  dynamo = jest.mock();
+  dynamoClient = jest.mock();
+  jest.mock("axios", () => ({ post: jest.fn(), create: jest.fn() }));
+
+  dynamoClient = buildFakeDynamoClient({
+    state: "abc123",
+    code: "the_fake_authorization_code",
+    refresh_token: "",
+    redirect_uri: "http://localhost/thisDoesNotMatter",
+  });
+});
+
+describe("tokenHandler clientCredentials", () => {
+  it("handles the client_credentials flow", async () => {
+    let req = new MockExpressRequest({
+      body: {
+        grant_type: "client_credentials",
+        client_assertion: "tbd",
+        client_assertion_type:
+          "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+        scopes: "launch/patient",
+        launch: "123V456",
+      },
+    });
+
+    const data = {
+      token_type: "Bearer",
+      expires_in: 3600,
+      access_token:
+        "eyJraWQiOiIzZkJCV0trc2JfY2ZmRGtYbVlSbmN1dGNtamFFMEFjeVdkdWFZc1NVa3o4IiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULnBwTUFxTG9UZ2VGamlCdUVnbmE0eWpCUGMzQWtUTndjRS1mVlgxVm4wVGMiLCJpc3MiOiJodHRwczovL2RlcHR2YS1ldmFsLm9rdGEuY29tL29hdXRoMi9hdXM4amExNXp6YjNwM21uWTJwNyIsImF1ZCI6Imh0dHBzOi8vc2FuZGJveC1hcGkudmEuZ292L3NlcnZpY2VzL2NjIiwiaWF0IjoxNjA0MzY5NDMxLCJleHAiOjE2MDQzNzMwMzEsImNpZCI6IjBvYThvNzlsM2pXMFd6WjFMMnA3Iiwic2NwIjpbImxhdW5jaC9wYXRpZW50Il0sInN1YiI6IjBvYThvNzlsM2pXMFd6WjFMMnA3IiwiYWJjIjoiMTIzIiwidGVzdCI6IjEyMyJ9.d4xtIXW4vmJIZoqdUu3UDr2jeQ0Boveibl-6qfvbjI9ETPvw8ZCiXtqqokUoZ3G2M6g1ZN6WOFlDTCFQc85qWGpLDT3VVNLmgML-26faC3Enj7fGSeJQKDOkwriGLr9Ep6upZm2Tl5dZFjeRseSHLA50YkVz1U55NH9fKT5Vsp4Ew9lllEqQs3-S0gGsiUBxGkvC7VGlsy8fXBYXd1e8T20Jw1hKyu4jSpS74gqSxhu_m0x_Aa7gUjF_A5irVv0xiVqxPdOnfN1od8JI0KnMYDgGzLgFrVft83cVD8imHUj_TvbTKehF-72-3jz3pg8a_vLu2Ld4Opzflk6J4ut-2w",
+      scope: "launch/patient",
+    };
+    mock.onPost(token_endpoint).reply(200, data);
+
+    let clientCredentialsStrategy = new ClientCredentialsStrategy(
+      req,
+      logger,
+      dynamo,
+      dynamoClient,
+      token_endpoint
+    );
+
+    let token = await clientCredentialsStrategy.getTokenResponse();
+    expect(token).toEqual(data);
+  });
+
+  it("handles invalid client_credentials request", async () => {
+    let req = new MockExpressRequest({
+      body: {
+        grant_type: "client_credentials",
+        client_assertion: "tbd",
+        client_assertion_type:
+          "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+        scopes: "launch/patient",
+        launch: "123V456",
+      },
+    });
+
+    const errResp = {
+      status: 401,
+      error: "invalid_client",
+      error_description: "The client_assertion token is expired.",
+      response: { error: "invalid_clients" },
+    };
+    mock.onPost(token_endpoint).reply(401, errResp);
+
+    let clientCredentialsStrategy = new ClientCredentialsStrategy(
+      req,
+      logger,
+      dynamo,
+      dynamoClient,
+      token_endpoint
+    );
+
+    try {
+      await clientCredentialsStrategy.getTokenResponse();
+    } catch (error) {
+      expect(error.statusCode).toEqual(401);
+      expect(error.error).toEqual("invalid_client");
+    }
+  });
+
+  it("handles client_credentials launch", async () => {
+    let req = new MockExpressRequest({
+      body: {
+        grant_type: "client_credentials",
+        client_assertion: "tbd",
+        client_assertion_type:
+          "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+        scopes: "launch/patient",
+        launch: "123V456",
+      },
+    });
+
+    let clientCredentialsStrategy = new ClientCredentialsStrategy(
+      req,
+      logger,
+      dynamo,
+      dynamoClient,
+      token_endpoint
+    );
+
+    let expectedPatient = await clientCredentialsStrategy.createPatientInfo(
+      null,
+      null
+    );
+    expect(expectedPatient).toEqual("123V456");
+  });
+});

--- a/oauth-proxy/tests/clientCredentialsStrategy.test.js
+++ b/oauth-proxy/tests/clientCredentialsStrategy.test.js
@@ -139,6 +139,43 @@ describe("tokenHandler clientCredentials", () => {
     }
   });
 
+  it("handles invalid client_credentials request unknown error", async () => {
+    let req = new MockExpressRequest({
+      body: {
+        grant_type: "client_credentials",
+        client_assertion: "unknown-failed-assertion",
+        client_assertion_type:
+          "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+        scopes: "launch/patient",
+        launch: "123V456",
+      },
+    });
+
+    const errResp = {
+      status: 500,
+      error: "unexpected_error",
+      response: { error: "unexpected_error" },
+    };
+    mock.onPost(token_endpoint).reply(500, errResp);
+
+    let clientCredentialsStrategy = new ClientCredentialsStrategy(
+      req,
+      logger,
+      dynamo,
+      dynamoClient,
+      token_endpoint
+    );
+
+    try {
+      await clientCredentialsStrategy.getTokenResponse();
+    } catch (error) {
+      expect(error.statusCode).toEqual(500);
+      expect(logger.error).toHaveBeenCalledWith({
+        message: "Server returned status code 500",
+      });
+    }
+  });
+
   it("handles client_credentials launch", async () => {
     let req = new MockExpressRequest({
       body: {

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -401,6 +401,34 @@ describe("OpenID Connect Conformance", () => {
     });
   });
 
+  it("returns an OIDC conformant token response to client_credentials", async () => {
+    const resp = await axios.post(
+      "http://localhost:9090/testServer/token",
+      qs.stringify({
+        grant_type: "client_credentials",
+        client_assertion: "tbd",
+        scopes: "launch/patient",
+        launch: "123V456",
+      }),
+      {
+        headers: {
+          origin: "http://localhost:8080",
+        },
+        auth: { username: "clientId123", password: "secretXyz" },
+      }
+    );
+
+    expect(resp.status).toEqual(200);
+    const parsedResp = resp.data;
+    const JWT_PATTERN = /[-_a-zA-Z0-9]+[.][-_a-zA-Z0-9]+[.][-_a-zA-Z0-9]+/;
+    expect(parsedResp).toMatchObject({
+      access_token: expect.stringMatching(JWT_PATTERN),
+      scope: expect.stringMatching(/.+/),
+      patient: expect.stringMatching("123V456"),
+      token_type: "Bearer",
+    });
+  });
+
   it("returns an OIDC conformant status 200 on token introspection", async () => {
     await axios
       .post(

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -407,6 +407,8 @@ describe("OpenID Connect Conformance", () => {
       qs.stringify({
         grant_type: "client_credentials",
         client_assertion: "tbd",
+        client_assertion_type:
+          "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
         scopes: "launch/patient",
         launch: "123V456",
       }),

--- a/oauth-proxy/tests/testUtils.js
+++ b/oauth-proxy/tests/testUtils.js
@@ -70,7 +70,8 @@ class FakeIssuer {
     };
     this.metadata = {
       issuer: "https://fake.okta.com/oauth2/1234",
-      authorization_endpoint: "fake_enpoint",
+      authorization_endpoint: "fake_endpoint",
+      token_endpoint: "fake_endpoint",
     };
   }
 }

--- a/oauth-proxy/tests/tokenHandler.test.js
+++ b/oauth-proxy/tests/tokenHandler.test.js
@@ -54,6 +54,8 @@ describe("tokenHandler clientCredentials", () => {
       body: {
         grant_type: "client_credentials",
         client_assertion: "tbd",
+        client_assertion_type:
+          "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
         scopes: "launch/patient",
         launch: "123V456",
       },

--- a/oauth-proxy/tests/tokenHandler.test.js
+++ b/oauth-proxy/tests/tokenHandler.test.js
@@ -60,18 +60,8 @@ describe("tokenHandler clientCredentials", () => {
         launch: "123V456",
       },
     });
-    dynamoClient = buildFakeDynamoClient({
-      state: "abc123",
-      code: "xyz789",
-      refresh_token: "the_fake_refresh_token",
-      redirect_uri: "http://localhost/thisDoesNotMatter",
-    });
 
     let res = new MockExpressResponse();
-    //TODO: Below not actually used..
-    validateToken = () => {
-      return { va_identifiers: { icn: "0000000000000" } };
-    };
     issuer = new FakeIssuer(dynamoClient);
     await tokenHandler(
       config,
@@ -86,6 +76,33 @@ describe("tokenHandler clientCredentials", () => {
       next
     );
     expect(res.statusCode).toEqual(200);
+  });
+
+  it("handles invalid client_credentials request", async () => {
+    let req = new MockExpressRequest({
+      body: {
+        grant_type: "client_credentials",
+        client_assertion: "tbd",
+        scopes: "launch/patient",
+        launch: "123V456",
+      },
+    });
+
+    let res = new MockExpressResponse();
+    issuer = new FakeIssuer(dynamoClient);
+    await tokenHandler(
+      config,
+      redirect_uri,
+      logger,
+      issuer,
+      dynamo,
+      dynamoClient,
+      null,
+      req,
+      res,
+      next
+    );
+    expect(res.statusCode).toEqual(400);
   });
 });
 

--- a/oauth-proxy/tests/tokenHandler.test.js
+++ b/oauth-proxy/tests/tokenHandler.test.js
@@ -48,6 +48,45 @@ afterEach(() => {
   expect(next).toHaveBeenCalled();
 });
 
+describe("tokenHandler clientCredentials", () => {
+  it("handles the client_credentials flow", async () => {
+    let req = new MockExpressRequest({
+      body: {
+        grant_type: "client_credentials",
+        client_assertion: "tbd",
+        scopes: "launch/patient",
+        launch: "123V456",
+      },
+    });
+    dynamoClient = buildFakeDynamoClient({
+      state: "abc123",
+      code: "xyz789",
+      refresh_token: "the_fake_refresh_token",
+      redirect_uri: "http://localhost/thisDoesNotMatter",
+    });
+
+    let res = new MockExpressResponse();
+    //TODO: Below not actually used..
+    validateToken = () => {
+      return { va_identifiers: { icn: "0000000000000" } };
+    };
+    issuer = new FakeIssuer(dynamoClient);
+    await tokenHandler(
+      config,
+      redirect_uri,
+      logger,
+      issuer,
+      dynamo,
+      dynamoClient,
+      validateToken,
+      req,
+      res,
+      next
+    );
+    expect(res.statusCode).toEqual(200);
+  });
+});
+
 describe("tokenHandler refresh", () => {
   it("handles the refresh flow", async () => {
     let req = new MockExpressRequest({

--- a/oauth-proxy/tests/upstreamOAuthTestServer.js
+++ b/oauth-proxy/tests/upstreamOAuthTestServer.js
@@ -42,6 +42,7 @@ function buildUpstreamOAuthTestApp() {
       ],
       grant_types_supported: [
         "authorization_code",
+        "client_credentials",
         "implicit",
         "refresh_token",
         "password",
@@ -56,6 +57,7 @@ function buildUpstreamOAuthTestApp() {
         "phone",
         "offline_access",
         "groups",
+        "launch/patient",
       ],
       token_endpoint_auth_methods_supported: [
         "client_secret_basic",


### PR DESCRIPTION
OAuth Proxy functionality added to support Client Credentials flow for configured trusted consumers.

Only JWT Bearer client_assertion's are valid.  The ICN can be supplied as an additional body arg as `launch`.

JIRA Issue: https://vajira.max.gov/browse/API-3015