### PR TITLE
Removed V0 validation endpoint references.

### DIFF
--- a/oauth-proxy/cli.js
+++ b/oauth-proxy/cli.js
@@ -61,14 +61,10 @@ function processArgs() {
         description: "okta API token",
         required: true,
       },
-      validate_endpoint: {
-        description: "va.gov token validation endpoint",
-        required: true,
-        default: "https://sandbox-api.va.gov/internal/auth/v0/validation",
-      },
       validate_post_endpoint: {
         description: "va.gov token validation endpoint",
-        required: false,
+        required: true,
+        default: "https://sandbox-api.va.gov/internal/auth/v1/validation",
       },
       manage_endpoint: {
         description:

--- a/oauth-proxy/dev-config.base.json
+++ b/oauth-proxy/dev-config.base.json
@@ -8,7 +8,6 @@
   "dynamo_client_credentials_table": "ClientCredentials",
   "hmac_secret": "secret",
   "okta_url": "https://deptva-eval.okta.com",
-  "validate_endpoint": "https://sandbox-api.va.gov/internal/auth/v0/validation",
   "validate_post_endpoint": "https://sandbox-api.va.gov/internal/auth/v1/validation",
   "manage_endpoint": "https://staging.va.gov/account",
   "validate_apiKey": "<FIX ME>",

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -473,7 +473,6 @@ function startApp(config, issuer, isolatedIssuers) {
   );
 
   const validateToken = configureTokenValidator(
-    config.validate_endpoint,
     config.validate_post_endpoint,
     config.validate_apiKey
   );

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -33,7 +33,7 @@ const defaultTestingConfig = {
   host: `http://localhost:${TEST_SERVER_PORT}`,
   well_known_base_path: "/testServer",
   upstream_issuer: upstreamOAuthTestServer.baseUrl(),
-  validate_endpoint: "http://localhost",
+  validate_post_endpoint: "http://localhost",
   validate_apiKey: "fakeApiKey",
   manage_endpoint: "http://localhost:9091/account",
   hmac_secret: "testsecret",

--- a/oauth-proxy/tests/testUtils.js
+++ b/oauth-proxy/tests/testUtils.js
@@ -234,7 +234,6 @@ const createFakeConfig = () => {
     dynamo_client_credentials_table: "ClientCredentials",
     hmac_secret: "secret",
     okta_url: "https://deptva-eval.okta.com",
-    validate_endpoint: "https://sandbox-api.va.gov/internal/auth/v0/validation",
     validate_post_endpoint:
       "https://sandbox-api.va.gov/internal/auth/v1/validation",
     manage_endpoint: "https://staging.va.gov/account",

--- a/oauth-proxy/tokenValidation.js
+++ b/oauth-proxy/tokenValidation.js
@@ -7,12 +7,7 @@ const axios = require("axios");
 // allowed to bubble up to the caller. You probably don't want to call this
 // directly. See configureTokenValidator below for a friendlier version.
 
-const validateToken = async (
-  post_endpoint,
-  api_key,
-  access_token,
-  aud
-) => {
+const validateToken = async (post_endpoint, api_key, access_token, aud) => {
   const validateTokenStart = process.hrtime.bigint();
   const response = await axios({
     method: "post",

--- a/oauth-proxy/tokenValidation.js
+++ b/oauth-proxy/tokenValidation.js
@@ -8,48 +8,32 @@ const axios = require("axios");
 // directly. See configureTokenValidator below for a friendlier version.
 
 const validateToken = async (
-  endpoint,
   post_endpoint,
   api_key,
   access_token,
   aud
 ) => {
   const validateTokenStart = process.hrtime.bigint();
-
-  // This if/else is only required until the post validation transition
-  // is completed across all environments.
-  if (post_endpoint) {
-    const response = await axios({
-      method: "post",
-      url: post_endpoint,
-      headers: {
-        apiKey: api_key,
-        authorization: `Bearer ${access_token}`,
-      },
-      data: {
-        aud: aud,
-      },
-    });
-    stopTimer(validationGauge, validateTokenStart);
-    return response.data.data.attributes;
-  } else {
-    const config = {
-      headers: {
-        apiKey: api_key,
-        authorization: `Bearer ${access_token}`,
-      },
-    };
-    const response = await axios.get(endpoint, config);
-    stopTimer(validationGauge, validateTokenStart);
-    return response.data.data.attributes;
-  }
+  const response = await axios({
+    method: "post",
+    url: post_endpoint,
+    headers: {
+      apiKey: api_key,
+      authorization: `Bearer ${access_token}`,
+    },
+    data: {
+      aud: aud,
+    },
+  });
+  stopTimer(validationGauge, validateTokenStart);
+  return response.data.data.attributes;
 };
 
 // Returns a function that calls validateToken with the given configuration
 // parameters.
-const configureTokenValidator = (endpoint, post_endpoint, api_key) => {
+const configureTokenValidator = (post_endpoint, api_key) => {
   return (access_token, aud) => {
-    return validateToken(endpoint, post_endpoint, api_key, access_token, aud);
+    return validateToken(post_endpoint, api_key, access_token, aud);
   };
 };
 


### PR DESCRIPTION
https://vajira.max.gov/browse/API-3054

Removed all v0 `validate_endpoint` references in favor of the v1 POST endpoint that includes the `aud` validation needed for OAuth isolation.

Note: Unlike most other OAuth proxy PR's, these code changes need to go prior to the devops change due to the `validate_endpoint` being configured as a required parameter

Corresponding Devops change: 
https://github.com/department-of-veterans-affairs/devops/pull/8174