### PR TITLE
expect_json_body compares by variables now

### DIFF
--- a/oauth-proxy/tests/scripts/assertions.sh
+++ b/oauth-proxy/tests/scripts/assertions.sh
@@ -100,16 +100,11 @@ expect_status() {
 # the JSON in file $curl_body
 #
 expect_json_body() {
-  expected_body="$(mktemp)"
-  echo "$EXPECTED_JSON" > "$expected_body"
-  actual_body="$(mktemp)"
-  echo "$JSON" > "$actual_body"
-
-  if [[ -z "$JSON" ]] || [ "$(cmp <(jq -cS . "$actual_body") <(jq -cS . "$expected_body"))" ]; then
+  if [[ -z "$JSON" ]] || [ "$(cmp <(echo "$JSON" | jq .) <(echo "$EXPECTED_JSON" | jq .))" ]; then
     echo "----"
     echo "FAIL:"
-    echo "  actual:   $(jq -cS . "$expected_body")"
-    echo "  expected: $(jq -cS . "$expected_body")"
+    echo "  actual:   $(echo "$JSON" | jq .)"
+    echo "  expected: $(echo "$EXPECTED_JSON" | jq .)"
     echo "----"
     return 1
   fi

--- a/oauth-proxy/tests/scripts/assertions.sh
+++ b/oauth-proxy/tests/scripts/assertions.sh
@@ -103,8 +103,8 @@ expect_json_body() {
   if [[ -z "$JSON" ]] || [ "$(cmp <(echo "$JSON" | jq .) <(echo "$EXPECTED_JSON" | jq .))" ]; then
     echo "----"
     echo "FAIL:"
-    echo "  actual:   $(echo "$JSON" | jq .)"
-    echo "  expected: $(echo "$EXPECTED_JSON" | jq .)"
+    echo "  actual:   $(echo "$JSON" | jq -c .)"
+    echo "  expected: $(echo "$EXPECTED_JSON" | jq -c .)"
     echo "----"
     return 1
   fi


### PR DESCRIPTION
Eliminated the use of temp files in the expect_json_body method. Now the regression tests are compatible with versions of jq under 1.6.