### PR TITLE
Api 3459 default category check

### DIFF
--- a/oauth-proxy/dev-config.base.json
+++ b/oauth-proxy/dev-config.base.json
@@ -18,6 +18,10 @@
   "routes": {
     "categories": [
       {
+        "api_category": "",
+        "upstream_issuer": "https://deptva-eval.okta.com/oauth2/default"
+      },
+      {
         "api_category": "/claims/v1",
         "upstream_issuer": "https://deptva-eval.okta.com/oauth2/aus7y0lyttrObgW622p7"
       },

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -132,11 +132,6 @@ function buildApp(
   const { well_known_base_path } = config;
   const redirect_uri = `${config.host}${well_known_base_path}${config.routes.app_routes.redirect}`;
 
-  /**
-   * @deprecated - To be removed following AuthZ Server reorganization
-   */
-  const metadataRewrite = buildMetadataRewriteTable(config);
-
   const app = express();
   const router = new express.Router();
   // Express needs to know it is being ran behind a trusted proxy. Setting 'trust proxy' to true does a few things
@@ -168,103 +163,112 @@ function buildApp(
     preflightContinue: true,
   });
 
-  // @deprecated - To be removed following AuthZ Server reorganization
-  router.options("/.well-known/*", corsHandler);
+  if (
+    !config.routes.categories.find((category) => category.api_category === "") >
+    0
+  ) {
+    /**
+     * @deprecated - To be removed following AuthZ Server reorganization
+     */
+    const metadataRewrite = buildMetadataRewriteTable(config);
+    // @deprecated - To be removed following AuthZ Server reorganization
+    router.options("/.well-known/*", corsHandler);
 
-  // @deprecated - To be removed following AuthZ Server reorganization
-  router.get("/.well-known/openid-configuration", corsHandler, (req, res) => {
-    const baseMetadata = { ...issuer.metadata, ...metadataRewrite };
-    const filteredMetadata = openidMetadataWhitelist.reduce((meta, key) => {
-      meta[key] = baseMetadata[key];
-      return meta;
-    }, {});
+    // @deprecated - To be removed following AuthZ Server reorganization
+    router.get("/.well-known/openid-configuration", corsHandler, (req, res) => {
+      const baseMetadata = { ...issuer.metadata, ...metadataRewrite };
+      const filteredMetadata = openidMetadataWhitelist.reduce((meta, key) => {
+        meta[key] = baseMetadata[key];
+        return meta;
+      }, {});
 
-    res.json(filteredMetadata);
-  });
+      res.json(filteredMetadata);
+    });
 
-  // @deprecated - To be removed following AuthZ Server reorganization
-  router.get(config.routes.app_routes.manage, (req, res) => {
-    res.redirect(config.manage_endpoint);
-  });
+    // @deprecated - To be removed following AuthZ Server reorganization
+    router.get(config.routes.app_routes.manage, (req, res) => {
+      res.redirect(config.manage_endpoint);
+    });
 
-  // @deprecated - To be removed following AuthZ Server reorganization
-  router.get(config.routes.app_routes.jwks, (req, res) =>
-    proxyRequestToOkta(req, res, issuer.metadata.jwks_uri, "GET")
-  );
-
-  // @deprecated - To be removed following AuthZ Server reorganization
-  router.get(config.routes.app_routes.userinfo, (req, res) =>
-    proxyRequestToOkta(req, res, issuer.metadata.userinfo_endpoint, "GET")
-  );
-
-  // @deprecated - To be removed following AuthZ Server reorganization
-  router.post(config.routes.app_routes.introspection, (req, res) =>
-    proxyRequestToOkta(
-      req,
-      res,
-      issuer.metadata.introspection_endpoint,
-      "POST",
-      querystring
-    )
-  );
-
-  // @deprecated - To be removed following AuthZ Server reorganization
-  router.post(config.routes.app_routes.revoke, (req, res) => {
-    proxyRequestToOkta(
-      req,
-      res,
-      issuer.metadata.revocation_endpoint,
-      "POST",
-      querystring
+    // @deprecated - To be removed following AuthZ Server reorganization
+    router.get(config.routes.app_routes.jwks, (req, res) =>
+      proxyRequestToOkta(req, res, issuer.metadata.jwks_uri, "GET")
     );
-  });
+
+    // @deprecated - To be removed following AuthZ Server reorganization
+    router.get(config.routes.app_routes.userinfo, (req, res) =>
+      proxyRequestToOkta(req, res, issuer.metadata.userinfo_endpoint, "GET")
+    );
+
+    // @deprecated - To be removed following AuthZ Server reorganization
+    router.post(config.routes.app_routes.introspection, (req, res) =>
+      proxyRequestToOkta(
+        req,
+        res,
+        issuer.metadata.introspection_endpoint,
+        "POST",
+        querystring
+      )
+    );
+
+    // @deprecated - To be removed following AuthZ Server reorganization
+    router.post(config.routes.app_routes.revoke, (req, res) => {
+      proxyRequestToOkta(
+        req,
+        res,
+        issuer.metadata.revocation_endpoint,
+        "POST",
+        querystring
+      );
+    });
+
+    // @deprecated - To be removed following AuthZ Server reorganization
+    router.get(config.routes.app_routes.authorize, async (req, res, next) => {
+      await oauthHandlers
+        .authorizeHandler(
+          config,
+          redirect_uri,
+          logger,
+          issuer,
+          dynamo,
+          dynamoClient,
+          oktaClient,
+          req,
+          res,
+          next
+        )
+        .catch(next);
+    });
+
+    // @deprecated - To be removed following AuthZ Server reorganization
+    router.post(config.routes.app_routes.token, async (req, res, next) => {
+      await oauthHandlers
+        .tokenHandler(
+          config,
+          redirect_uri,
+          logger,
+          issuer,
+          dynamo,
+          dynamoClient,
+          validateToken,
+          req,
+          res,
+          next
+        )
+        .catch(next);
+    });
+
+    // @deprecated - To be removed following AuthZ Server reorganization
+    router.delete(config.routes.app_routes.grants, async (req, res, next) => {
+      await oauthHandlers
+        .revokeUserGrantHandler(oktaClient, config, req, res, next)
+        .catch(next);
+    });
+  }
 
   router.get(config.routes.app_routes.redirect, async (req, res, next) => {
     await oauthHandlers
       .redirectHandler(logger, dynamo, dynamoClient, config, req, res, next)
-      .catch(next);
-  });
-
-  // @deprecated - To be removed following AuthZ Server reorganization
-  router.get(config.routes.app_routes.authorize, async (req, res, next) => {
-    await oauthHandlers
-      .authorizeHandler(
-        config,
-        redirect_uri,
-        logger,
-        issuer,
-        dynamo,
-        dynamoClient,
-        oktaClient,
-        req,
-        res,
-        next
-      )
-      .catch(next);
-  });
-
-  // @deprecated - To be removed following AuthZ Server reorganization
-  router.post(config.routes.app_routes.token, async (req, res, next) => {
-    await oauthHandlers
-      .tokenHandler(
-        config,
-        redirect_uri,
-        logger,
-        issuer,
-        dynamo,
-        dynamoClient,
-        validateToken,
-        req,
-        res,
-        next
-      )
-      .catch(next);
-  });
-
-  // @deprecated - To be removed following AuthZ Server reorganization
-  router.delete(config.routes.app_routes.grants, async (req, res, next) => {
-    await oauthHandlers
-      .revokeUserGrantHandler(oktaClient, config, req, res, next)
       .catch(next);
   });
 

--- a/oauth-proxy/index.js
+++ b/oauth-proxy/index.js
@@ -362,6 +362,7 @@ function buildApp(
       config,
       api_category
     );
+    router.options(api_category + "/.well-known/*", corsHandler);
     router.get(
       api_category + "/.well-known/openid-configuration",
       corsHandler,


### PR DESCRIPTION
Preliminary PR to removing default routes. Checks for default api_category in the app config. Will use default routes if no default api_category then it will use the default routes.

[API3459-Tests.docx](https://github.com/department-of-veterans-affairs/vets-saml-proxy/files/5705316/API3459-Tests.docx)
