### PR TITLE
Api 4749 OAuth proxy rename launch context table

### DIFF
--- a/oauth-proxy/cli.js
+++ b/oauth-proxy/cli.js
@@ -39,8 +39,8 @@ function processArgs() {
         description: "flag to use local DynamoDB instance",
         required: false,
       },
-      dynamo_client_credentials_table: {
-        description: "name of client credentials table.",
+      dynamo_launch_context_table: {
+        description: "name of launch context table.",
         required: true,
       },
       dynamo_static_token_table: {

--- a/oauth-proxy/dev-config.base.json
+++ b/oauth-proxy/dev-config.base.json
@@ -4,7 +4,7 @@
   "upstream_issuer_timeout_ms": 15000,
   "dynamo_local": "dynamodb:8000",
   "dynamo_table_name": "OAuthRequests",
-  "dynamo_client_credentials_table": "ClientCredentials",
+  "dynamo_launch_context_table": "LaunchContext",
   "dynamo_static_token_table": "StaticTokens",
   "hmac_secret": "secret",
   "okta_url": "https://deptva-eval.okta.com",

--- a/oauth-proxy/dynamo_schema.js
+++ b/oauth-proxy/dynamo_schema.js
@@ -118,7 +118,7 @@ tableParams = {
       },
     },
   ],
-  TableName: "ClientCredentials",
+  TableName: "LaunchContext",
 };
 
 dynamo.createTable(tableParams, (err, data) => {

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/documentStrategies/getDocumentByAccessTokenStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/documentStrategies/getDocumentByAccessTokenStrategy.js
@@ -18,7 +18,7 @@ class GetDocumentByAccessTokenStrategy {
         {
           access_token: hashedToken,
         },
-        this.config.dynamo_client_credentials_table
+        this.config.dynamo_launch_context_table
       );
       if (payload.Item) {
         document = payload.Item;

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentLaunchStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentLaunchStrategy.js
@@ -24,7 +24,7 @@ class SaveDocumentLaunchStrategy {
 
         await this.dynamoClient.savePayloadToDynamo(
           payload,
-          this.config.dynamo_client_credentials_table
+          this.config.dynamo_launch_context_table
         );
       }
     } catch (error) {

--- a/oauth-proxy/tests/dynamo_client.test.js
+++ b/oauth-proxy/tests/dynamo_client.test.js
@@ -22,10 +22,7 @@ describe("dynamo client tests", () => {
     });
 
     try {
-      await dynamoclient.savePayloadToDynamo(
-        { pay: "load" },
-        "LaunchContext"
-      );
+      await dynamoclient.savePayloadToDynamo({ pay: "load" }, "LaunchContext");
       expect(isCalled).toEqual(true);
     } catch (err) {
       // should not reach here
@@ -39,10 +36,7 @@ describe("dynamo client tests", () => {
     });
 
     try {
-      await dynamoclient.savePayloadToDynamo(
-        { pay: "load" },
-        "LaunchContext"
-      );
+      await dynamoclient.savePayloadToDynamo({ pay: "load" }, "LaunchContext");
       // should not reach here
       fail("Should not reach here");
     } catch (err) {

--- a/oauth-proxy/tests/dynamo_client.test.js
+++ b/oauth-proxy/tests/dynamo_client.test.js
@@ -24,7 +24,7 @@ describe("dynamo client tests", () => {
     try {
       await dynamoclient.savePayloadToDynamo(
         { pay: "load" },
-        "ClientCredentials"
+        "LaunchContext"
       );
       expect(isCalled).toEqual(true);
     } catch (err) {
@@ -41,7 +41,7 @@ describe("dynamo client tests", () => {
     try {
       await dynamoclient.savePayloadToDynamo(
         { pay: "load" },
-        "ClientCredentials"
+        "LaunchContext"
       );
       // should not reach here
       fail("Should not reach here");

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -101,7 +101,7 @@ function buildFakeDynamoClient(fakeDynamoClientRecord) {
     return new Promise((resolve, reject) => {
       let searchKey = Object.keys(search_params)[0];
       if (
-        tableName === "client_creds_table" &&
+        tableName === "launch_context_table" &&
         searchKey === "access_token" &&
         search_params[searchKey] === hashed_smart_launch_token
       ) {

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -40,7 +40,7 @@ const defaultTestingConfig = {
   validate_apiKey: "fakeApiKey",
   manage_endpoint: "http://localhost:9091/account",
   hmac_secret: "testsecret",
-  dynamo_client_credentials_table: "client_creds_table",
+  dynamo_launch_context_table: "launch_context_table",
   enable_smart_launch_service: true,
   enable_static_token_service: true,
   routes: {

--- a/oauth-proxy/tests/testUtils.js
+++ b/oauth-proxy/tests/testUtils.js
@@ -271,7 +271,7 @@ const createFakeConfig = () => {
     upstream_issuer_timeout_ms: 15000,
     dynamo_local: "dynamodb:8000",
     dynamo_table_name: "OAuthRequests",
-    dynamo_client_credentials_table: "ClientCredentials",
+    dynamo_launch_context_table: "LaunchContext",
     hmac_secret: "secret",
     okta_url: "https://deptva-eval.okta.com",
     validate_post_endpoint:


### PR DESCRIPTION
### Description
As part of API-4749 changes to support SSOi the scope of the ClientCredentials table is growing to more than client credentials.  The table is being renamed to LaunchContext since that is its generic purpose for both Client Credentials auth and Authorization Code auth + SSOi.

Tentative plan is a back up and restore (with rename) of the existing Dynamo table in each environment.
https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Restore.Tutorial.html

### Relations
- https://vajira.max.gov/browse/API-4749
- https://github.com/department-of-veterans-affairs/devops/pull/8444 (Dev, Sandbox, Prod)
- https://github.com/department-of-veterans-affairs/lighthouse-oauth-proxy-configs/pull/12 (Staging)
