### PR TITLE
Metadata endpoint is configurable

### DIFF
--- a/oauth-proxy/dev-config.base.json
+++ b/oauth-proxy/dev-config.base.json
@@ -20,31 +20,38 @@
     "categories": [
       {
         "api_category": "",
-        "upstream_issuer": "https://deptva-eval.okta.com/oauth2/default"
+        "upstream_issuer": "https://deptva-eval.okta.com/oauth2/default",
+        "metadata_endpoint": ""
       },
       {
         "api_category": "/claims/v1",
-        "upstream_issuer": "https://deptva-eval.okta.com/oauth2/aus7y0lyttrObgW622p7"
+        "upstream_issuer": "https://deptva-eval.okta.com/oauth2/aus7y0lyttrObgW622p7",
+        "metadata_endpoint": ""
       },
       {
         "api_category": "/community-care/v1",
-        "upstream_issuer": "https://deptva-eval.okta.com/oauth2/aus89xnh1xznM13SK2p7"
+        "upstream_issuer": "https://deptva-eval.okta.com/oauth2/aus89xnh1xznM13SK2p7",
+        "metadata_endpoint": ""
       },
       {
         "api_category": "/health/v1",
-        "upstream_issuer": "https://deptva-eval.okta.com/oauth2/default"
+        "upstream_issuer": "https://deptva-eval.okta.com/oauth2/default",
+        "metadata_endpoint": ""
       },
       {
         "api_category": "/health-insurance/v1",
-        "upstream_issuer": "https://deptva-eval.okta.com/oauth2/aus8nm1q0f7VQ0a482p7"
+        "upstream_issuer": "https://deptva-eval.okta.com/oauth2/aus8nm1q0f7VQ0a482p7",
+        "metadata_endpoint": ""
       },
       {
         "api_category": "/pgd/v1",
-        "upstream_issuer": "https://deptva-eval.okta.com/oauth2/aus8x27nv4g4BS01v2p7"
+        "upstream_issuer": "https://deptva-eval.okta.com/oauth2/aus8x27nv4g4BS01v2p7",
+        "metadata_endpoint": ""
       },
       {
         "api_category": "/veteran-verification/v1",
-        "upstream_issuer": "https://deptva-eval.okta.com/oauth2/aus7y0sefudDrg2HI2p7"
+        "upstream_issuer": "https://deptva-eval.okta.com/oauth2/aus7y0sefudDrg2HI2p7",
+        "metadata_endpoint": ""
       }
     ],
     "app_routes": {


### PR DESCRIPTION
~~Metadata is now determined by the api_category field "metadata_endpoint".~~

```
{
  "api_category": "/ssoi/v1",
  "upstream_issuer": "https://example-issuer.com",
  "metadata_endpoint": "https://example-issuer.com/metadata"
}
```

~~TODO~~

~~- [ ] Update example Config~~
~~- [ ] Update CLI (and other files that are involved in config updates)~~
~~- [ ] Create PR to Include metadata_endpoint in environment configs~~
~~- [ ] Test Docs~~
~~- [ ] Add Metadata test for Integration Shell Script~~
~~- [ ] e2e tests~~
~~- [ ] functionality~~

I have confirmed the OpenId handler module is compatible with IAM endpoints. Closing with no Action.