### PR TITLE
Added missing IDP slug parameter to authorize launch tests.

### DIFF
--- a/oauth-proxy/tests/authorizeHandler.test.js
+++ b/oauth-proxy/tests/authorizeHandler.test.js
@@ -356,6 +356,7 @@ describe("authorizeHandler", () => {
       issuer,
       dynamoClient,
       oktaClient,
+      mockSlugHelper,
       req,
       res,
       next
@@ -387,6 +388,7 @@ describe("authorizeHandler", () => {
       issuer,
       dynamoClient,
       oktaClient,
+      mockSlugHelper,
       req,
       res,
       next


### PR DESCRIPTION
After the SMART launch PR was merged it looks like there are a couple failures on master build that weren't on the PR build.

A `TypeError: Cannot destructure property 'state' of for both failures.` resulted from the missing IDP `mockSlugHelper`.

Add to 2 launch authorize tests to fix.
