### PR TITLE
API-5200 - Add health/system authz route

### DIFF
--- a/oauth-proxy/dev-config.base.json
+++ b/oauth-proxy/dev-config.base.json
@@ -39,6 +39,10 @@
         "upstream_issuer": "https://deptva-eval.okta.com/oauth2/aus8nm1q0f7VQ0a482p7"
       },
       {
+        "api_category": "/health/system/v1",
+        "upstream_issuer": "https://deptva-eval.okta.com/oauth2/aus8nm1q0f7VQ0a482p7"
+      },
+      {
         "api_category": "/pgd/v1",
         "upstream_issuer": "https://deptva-eval.okta.com/oauth2/aus8x27nv4g4BS01v2p7"
       },


### PR DESCRIPTION
Add new `health/system` route for consumers using client_credentials to access Health APIs.

This route will replace the single purpose `health-insurance` route. Lighthouse will work with existing consumers (1) to migrate them onto `health/system`.

Scopes will be assigned by policy/rule. This allows all system consumers to use the same authz route.