### PR TITLE
Added Metadata endpoint test

### DIFF
--- a/oauth-proxy/tests/scripts/other_tests.sh
+++ b/oauth-proxy/tests/scripts/other_tests.sh
@@ -187,6 +187,8 @@ curl -s \
 "$DIR"/assertions.sh --expect-status --status="$(cat "$curl_status")" --expected-status=400
 track_result
 
+echo -e "\tRunning ... Metadata endpoint test"
+
 if [[ $pass -lt 1 ]];
 then
   echo -e "\tFAIL - Some misc. tests did not pass."

--- a/oauth-proxy/tests/scripts/other_tests.sh
+++ b/oauth-proxy/tests/scripts/other_tests.sh
@@ -189,6 +189,54 @@ track_result
 
 echo -e "\tRunning ... Metadata endpoint test"
 
+curl -s \
+  -w "%{http_code}" \
+  -o "$curl_body" \
+  "$HOST/.well-known/openid-configuration" > "$curl_status"
+
+"$DIR"/assertions.sh --expect-status --status="$(cat "$curl_status")" --expected-status=200
+track_result
+"$DIR"/assertions.sh --has-or-expect-property --json="$(cat "$curl_body")" --property="issuer" --expected-value="$ISSUER"
+track_result
+"$DIR"/assertions.sh --has-or-expect-property --json="$(cat "$curl_body")" --property="authorization_endpoint" --expected-value="$AUTHORIZATION_ENDPOINT"
+track_result
+"$DIR"/assertions.sh --has-or-expect-property --json="$(cat "$curl_body")" --property="token_endpoint" --expected-value="$TOKEN_ENDPOINT"
+track_result
+"$DIR"/assertions.sh --has-or-expect-property --json="$(cat "$curl_body")" --property="userinfo_endpoint" --expected-value="$USERINFO_ENDPOINT"
+track_result
+"$DIR"/assertions.sh --has-or-expect-property --json="$(cat "$curl_body")" --property="introspection_endpoint" --expected-value="$INTROSPECTION_ENDPOINT"
+track_result
+"$DIR"/assertions.sh --has-or-expect-property --json="$(cat "$curl_body")" --property="revocation_endpoint" --expected-value="$REVOCATION_ENDPOINT"
+track_result
+"$DIR"/assertions.sh --has-or-expect-property --json="$(cat "$curl_body")" --property="jwks_uri" --expected-value="$JWKS_URI"
+track_result
+"$DIR"/assertions.sh --has-property --json="$(cat "$curl_body")" --property="scopes_supported"
+track_result
+"$DIR"/assertions.sh --has-property --json="$(cat "$curl_body")" --property="response_types_supported"
+track_result
+"$DIR"/assertions.sh --has-property --json="$(cat "$curl_body")" --property="response_modes_supported"
+track_result
+"$DIR"/assertions.sh --has-property --json="$(cat "$curl_body")" --property="grant_types_supported"
+track_result
+"$DIR"/assertions.sh --has-property --json="$(cat "$curl_body")" --property="subject_types_supported"
+track_result
+"$DIR"/assertions.sh --has-property --json="$(cat "$curl_body")" --property="id_token_signing_alg_values_supported"
+track_result
+"$DIR"/assertions.sh --has-property --json="$(cat "$curl_body")" --property="token_endpoint_auth_methods_supported"
+track_result
+"$DIR"/assertions.sh --has-property --json="$(cat "$curl_body")" --property="revocation_endpoint_auth_methods_supported"
+track_result
+"$DIR"/assertions.sh --has-property --json="$(cat "$curl_body")" --property="claims_supported"
+track_result
+"$DIR"/assertions.sh --has-property --json="$(cat "$curl_body")" --property="code_challenge_methods_supported"
+track_result
+"$DIR"/assertions.sh --has-property --json="$(cat "$curl_body")" --property="introspection_endpoint_auth_methods_supported"
+track_result
+"$DIR"/assertions.sh --has-property --json="$(cat "$curl_body")" --property="request_parameter_supported"
+track_result
+"$DIR"/assertions.sh --has-property --json="$(cat "$curl_body")" --property="request_object_signing_alg_values_supported"
+track_result
+
 if [[ $pass -lt 1 ]];
 then
   echo -e "\tFAIL - Some misc. tests did not pass."


### PR DESCRIPTION
# Description

To Support API-5294, a regression test should be added to the scripted regression test suite for the metadata endpoint.

## AC

- [x] Test checks for a `200` status code
- [x] Checks for all of the metadata endpoints
- [x] Check for the metadata endpoint value if specified (only applicable to certain fields, see below)

**Metadata Endpoints**

- [x] issuer | Supports Value Check
- [x] authorization_endpoint | Supports Value Check
- [x] token_endpoint | Supports Value Check
- [x] userinfo_endpoint | Supports Value Check
- [x] introspection_endpoint | Supports Value Check
- [x] revocation_endpoint | Supports Value Check
- [x] jwks_uri | Supports Value Check
- [x] scopes_supported
- [x] response_types_supported
- [x] response_modes_supported
- [x] grant_types_supported
- [x] subject_types_supported
- [x] id_token_signing_alg_values_supported
- [x] token_endpoint_auth_methods_supported
- [x] revocation_endpoint_auth_methods_supported
- [x] claims_supported
- [x] code_challenge_methods_supported
- [x] introspection_endpoint_auth_methods_supported
- [x] request_parameter_supported
- [x] request_object_signing_alg_values_supported

## How will the value check work?

Endpoints with value checks will be represented by global variables which contain their expected values. If the global variables exists, the tests will check against the values. If they do not exist the test will only check if the value exists.

The global variables are as follows:

- ISSUER = issuer
- AUTHORIZATION_ENDPOINT = authorization_endpoint 
- TOKEN_ENDPOINT = token_endpoint 
- USERINFO_ENDPOINT = userinfo_endpoint 
- INTROSPECTION_ENDPOINT =  introspection_endpoint
- REVOCATION_ENDPOINT = revocation_endpoint 
- JWKS_URI = jwks_uri 

## Tests

### No Global Variables specified

**Expected Results**

- [x]  Tests should pass

### All correct global variables specified

**Input**

```sh
export ISSUER=placeholder
export AUTHORIZATION_ENDPOINT=placeholder
export TOKEN_ENDPOINT=placeholder
export USERINFO_ENDPOINT=placeholder
export INTROSPECTION_ENDPOINT=placeholder
export REVOCATION_ENDPOINT=placeholder
export JWKS_URI=placeholder
```

**Expected Results**

- [x] Tests should pass

### All incorrect global variables specified

**Input**

```sh
export ISSUER=bad
export AUTHORIZATION_ENDPOINT=bad
export TOKEN_ENDPOINT=bad
export USERINFO_ENDPOINT=bad
export INTROSPECTION_ENDPOINT=bad
export REVOCATION_ENDPOINT=bad
export JWKS_URI=bad
```

**Expected Results**

- [x] Metadata test should fail