### PR TITLE
Authorize Handler Refactor

### DIFF
--- a/oauth-proxy/oauthHandlers/authorizeHandler.js
+++ b/oauth-proxy/oauthHandlers/authorizeHandler.js
@@ -1,7 +1,25 @@
+/** @module issuer_helper */
 const { URLSearchParams, URL } = require("url");
 const { loginBegin } = require("../metrics");
 const { v4: uuidv4 } = require("uuid");
 
+/**
+ * Checks for valid authorization request and proxies to authorization server.
+ *
+ * @param {string} redirect_uri uri the authorization response will be sent to.
+ * @param {*} logger logs information.
+ * @param {*} issuer holds information and sends request to token issuer.
+ * @param {*} dynamoClient interacts with dynamodb.
+ * @param {*} oktaClient interacts with okta api.
+ * @param {*} slugHelper rewrites identity provider id to slug.
+ * @param {*} app_category contains information on the route's specific issuer and auth server.
+ * @param {string} dynamo_oauth_requests_table table that stores oauth request information.
+ * @param {string} dynamo_clients_table table that stores client information.
+ * @param {*} idp id of identify provider.
+ * @param {*} req express request object.
+ * @param {*} res express response object.
+ * @param {*} next express next object.
+ */
 const authorizeHandler = async (
   redirect_uri,
   logger,
@@ -100,6 +118,11 @@ const authorizeHandler = async (
   );
 };
 
+/**
+ * Checks for valid authorization parameters.
+ *
+ * @returns {Promise<{valid: boolean, error_description: string, error: string}>}
+ */
 const checkParameters = async (
   state,
   aud,
@@ -153,6 +176,11 @@ const checkParameters = async (
   return { valid: true };
 };
 
+/**
+ * Checks for authorization server or local database for valid client.
+ *
+ * @returns {Promise<{valid: boolean, error_description: string}>}
+ */
 const validateClient = async (
   logger,
   client_id,
@@ -180,6 +208,11 @@ const validateClient = async (
   );
 };
 
+/**
+ * Checks for authorization local database for valid client.
+ *
+ * @returns {Promise<{valid: boolean, error_description: string}>}
+ */
 const localValidateClient = async (
   logger,
   client_id,
@@ -222,6 +255,11 @@ const localValidateClient = async (
   return { valid: true };
 };
 
+/**
+ * Checks for authorization server for valid client.
+ *
+ * @returns {Promise<{valid: boolean, error_description: string}>}
+ */
 const serverValidateClient = async (
   oktaClient,
   logger,

--- a/oauth-proxy/oauthHandlers/authorizeHandler.js
+++ b/oauth-proxy/oauthHandlers/authorizeHandler.js
@@ -1,7 +1,7 @@
 const { URLSearchParams, URL } = require("url");
 const { loginBegin } = require("../metrics");
 const { v4: uuidv4 } = require("uuid");
-// Refactor this ..
+
 const authorizeHandler = async (
   redirect_uri,
   logger,

--- a/oauth-proxy/oauthHandlers/authorizeHandler.js
+++ b/oauth-proxy/oauthHandlers/authorizeHandler.js
@@ -1,7 +1,7 @@
 const { URLSearchParams, URL } = require("url");
 const { loginBegin } = require("../metrics");
 const { v4: uuidv4 } = require("uuid");
-
+// Refactor this ..
 const authorizeHandler = async (
   redirect_uri,
   logger,

--- a/oauth-proxy/tests/authorizeHandler.test.js
+++ b/oauth-proxy/tests/authorizeHandler.test.js
@@ -70,15 +70,11 @@ beforeEach(() => {
   });
 
   issuer = new FakeIssuer(dynamoClient);
+
+  getAuthorizationServerInfoMock.mockReset();
 });
 
-describe("authorizeHandler", () => {
-  afterEach(() => {});
-
-  beforeEach(() => {
-    getAuthorizationServerInfoMock.mockReset();
-  });
-
+describe("Happy Path", () => {
   it("Happy Path Redirect", async () => {
     let response = buildFakeGetAuthorizationServerInfoResponse(["aud"]);
     getAuthorizationServerInfoMock.mockResolvedValue(response);
@@ -219,6 +215,123 @@ describe("authorizeHandler", () => {
     expect(res.redirect).toHaveBeenCalled();
   });
 
+  it("Verify that context is saved for SMART launch", async () => {
+    let response = buildFakeGetAuthorizationServerInfoResponse(["aud"]);
+    getAuthorizationServerInfoMock.mockResolvedValue(response);
+    res = {
+      redirect: jest.fn(),
+    };
+
+    req.query = {
+      state: "fake_state",
+      client_id: "clientId123",
+      redirect_uri: "http://localhost:8080/oauth/redirect",
+      scope: "openid profile offline_access launch/patient",
+      launch: "123V456",
+      aud: "aud",
+    };
+
+    await authorizeHandler(
+      redirect_uri,
+      logger,
+      issuer,
+      dynamoClient,
+      oktaClient,
+      mockSlugHelper,
+      api_category,
+      "OAuthRequestsV2",
+      "Clients",
+      "idp1",
+      req,
+      res,
+      next
+    );
+
+    expect(res.redirect).toHaveBeenCalled();
+  });
+
+  it("Verify that JWT context is saved for SMART launch", async () => {
+    let response = buildFakeGetAuthorizationServerInfoResponse(["aud"]);
+    getAuthorizationServerInfoMock.mockResolvedValue(response);
+    res = {
+      redirect: jest.fn(),
+    };
+
+    req.query = {
+      state: "fake_state",
+      client_id: "clientId123",
+      redirect_uri: "http://localhost:8080/oauth/redirect",
+      scope: "openid profile offline_access launch",
+      launch:
+        "ewogICJwYXRpZW50IjogIjEyMzRWNTY3OCIsCiAgImVuY291bnRlciI6ICI5ODc2LTU0MzItMTAwMCIKfQ==",
+      aud: "aud",
+    };
+
+    await authorizeHandler(
+      redirect_uri,
+      logger,
+      issuer,
+      dynamoClient,
+      oktaClient,
+      mockSlugHelper,
+      api_category,
+      "OAuthRequestsV2",
+      "Clients",
+      "idp1",
+      req,
+      res,
+      next
+    );
+
+    expect(res.redirect).toHaveBeenCalled();
+  });
+
+  it("Happy path auth with local client flag", async () => {
+    dynamoClient = buildFakeDynamoClient({
+      client_id: "clientId123",
+      redirect_uris: { values: ["http://localhost:8080/oauth/redirect"] },
+    });
+
+    let response = buildFakeGetAuthorizationServerInfoResponse(["aud"]);
+    getAuthorizationServerInfoMock.mockResolvedValue(response);
+    res = {
+      redirect: jest.fn(),
+    };
+
+    req.query = {
+      state: "fake_state",
+      client_id: "clientId123",
+      redirect_uri: "http://localhost:8080/oauth/redirect",
+    };
+
+    api_category.client_store = "local";
+
+    await authorizeHandler(
+      redirect_uri,
+      logger,
+      issuer,
+      dynamoClient,
+      oktaClient,
+      mockSlugHelper,
+      api_category,
+      "OAuthRequestsV2",
+      "Clients",
+      "idp1",
+      req,
+      res,
+      next
+    );
+
+    expect(res.redirect).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+    expect(dynamoClient.getPayloadFromDynamo).toHaveBeenCalledWith(
+      { client_id: "clientId123" },
+      "Clients"
+    );
+  });
+});
+
+describe("Invalid Request", () => {
   it("Verify that empty string redirect_uri results in 400", async () => {
     let response = buildFakeGetAuthorizationServerInfoResponse(["aud"]);
     getAuthorizationServerInfoMock.mockResolvedValue(response);
@@ -318,40 +431,6 @@ describe("authorizeHandler", () => {
       expected: response.audiences,
     });
     expect(res.redirect).toHaveBeenCalled();
-  });
-
-  it("getAuthorizationServerInfo Error, return 500", async () => {
-    getAuthorizationServerInfoMock.mockRejectedValue({ error: "fakeError" });
-
-    req.query = {
-      state: "fake_state",
-      client_id: "clientId123",
-      redirect_uri: "http://localhost:8080/oauth/redirect",
-      aud: "notAPIValue",
-    };
-
-    await authorizeHandler(
-      redirect_uri,
-      logger,
-      issuer,
-      dynamoClient,
-      oktaClient,
-      mockSlugHelper,
-      api_category,
-      "OAuthRequestsV2",
-      "Clients",
-      "idp1",
-      req,
-      res,
-      next
-    );
-
-    expect(logger.error).toHaveBeenCalledWith(
-      "Unable to get the authorization server."
-    );
-    expect(next).toHaveBeenCalledWith({
-      status: 500,
-    });
   });
 
   it("No client_redirect, returns 400", async () => {
@@ -477,121 +556,6 @@ describe("authorizeHandler", () => {
     expect(res.statusCode).toEqual(400);
   });
 
-  it("Verify that context is saved for SMART launch", async () => {
-    let response = buildFakeGetAuthorizationServerInfoResponse(["aud"]);
-    getAuthorizationServerInfoMock.mockResolvedValue(response);
-    res = {
-      redirect: jest.fn(),
-    };
-
-    req.query = {
-      state: "fake_state",
-      client_id: "clientId123",
-      redirect_uri: "http://localhost:8080/oauth/redirect",
-      scope: "openid profile offline_access launch/patient",
-      launch: "123V456",
-      aud: "aud",
-    };
-
-    await authorizeHandler(
-      redirect_uri,
-      logger,
-      issuer,
-      dynamoClient,
-      oktaClient,
-      mockSlugHelper,
-      api_category,
-      "OAuthRequestsV2",
-      "Clients",
-      "idp1",
-      req,
-      res,
-      next
-    );
-
-    expect(res.redirect).toHaveBeenCalled();
-  });
-
-  it("Verify that JWT context is saved for SMART launch", async () => {
-    let response = buildFakeGetAuthorizationServerInfoResponse(["aud"]);
-    getAuthorizationServerInfoMock.mockResolvedValue(response);
-    res = {
-      redirect: jest.fn(),
-    };
-
-    req.query = {
-      state: "fake_state",
-      client_id: "clientId123",
-      redirect_uri: "http://localhost:8080/oauth/redirect",
-      scope: "openid profile offline_access launch",
-      launch:
-        "ewogICJwYXRpZW50IjogIjEyMzRWNTY3OCIsCiAgImVuY291bnRlciI6ICI5ODc2LTU0MzItMTAwMCIKfQ==",
-      aud: "aud",
-    };
-
-    await authorizeHandler(
-      redirect_uri,
-      logger,
-      issuer,
-      dynamoClient,
-      oktaClient,
-      mockSlugHelper,
-      api_category,
-      "OAuthRequestsV2",
-      "Clients",
-      "idp1",
-      req,
-      res,
-      next
-    );
-
-    expect(res.redirect).toHaveBeenCalled();
-  });
-
-  it("Happy path auth with local client flag", async () => {
-    dynamoClient = buildFakeDynamoClient({
-      client_id: "clientId123",
-      redirect_uris: { values: ["http://localhost:8080/oauth/redirect"] },
-    });
-
-    let response = buildFakeGetAuthorizationServerInfoResponse(["aud"]);
-    getAuthorizationServerInfoMock.mockResolvedValue(response);
-    res = {
-      redirect: jest.fn(),
-    };
-
-    req.query = {
-      state: "fake_state",
-      client_id: "clientId123",
-      redirect_uri: "http://localhost:8080/oauth/redirect",
-    };
-
-    api_category.client_store = "local";
-
-    await authorizeHandler(
-      redirect_uri,
-      logger,
-      issuer,
-      dynamoClient,
-      oktaClient,
-      mockSlugHelper,
-      api_category,
-      "OAuthRequestsV2",
-      "Clients",
-      "idp1",
-      req,
-      res,
-      next
-    );
-
-    expect(res.redirect).toHaveBeenCalled();
-    expect(next).not.toHaveBeenCalled();
-    expect(dynamoClient.getPayloadFromDynamo).toHaveBeenCalledWith(
-      { client_id: "clientId123" },
-      "Clients"
-    );
-  });
-
   it("Invalid path in request", async () => {
     dynamoClient = buildFakeDynamoClient({
       client_id: "clientId123",
@@ -664,7 +628,90 @@ describe("authorizeHandler", () => {
     expect(next).toHaveBeenCalled();
     expect(res.redirect).not.toHaveBeenCalled();
   });
+});
 
+describe("Server Error", () => {
+  it("getAuthorizationServerInfo Error, return 500", async () => {
+    getAuthorizationServerInfoMock.mockRejectedValue({ error: "fakeError" });
+
+    req.query = {
+      state: "fake_state",
+      client_id: "clientId123",
+      redirect_uri: "http://localhost:8080/oauth/redirect",
+      aud: "notAPIValue",
+    };
+
+    await authorizeHandler(
+      redirect_uri,
+      logger,
+      issuer,
+      dynamoClient,
+      oktaClient,
+      mockSlugHelper,
+      api_category,
+      "OAuthRequestsV2",
+      "Clients",
+      "idp1",
+      req,
+      res,
+      next
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      "Unable to get the authorization server."
+    );
+    expect(next).toHaveBeenCalledWith({
+      status: 500,
+    });
+  });
+
+  it("Error on save to dynamo", async () => {
+    dynamoClient.savePayloadToDynamo = jest.fn().mockImplementation(() => {
+      return new Promise((resolve, reject) => {
+        // It's unclear whether this should resolve with a full records or just
+        // the identity field but thus far it has been irrelevant to the
+        // functional testing of the oauth-proxy.
+        reject({
+          error: "bad_things_error",
+          error_description: "Bad things happen",
+        });
+      });
+    });
+
+    let response = buildFakeGetAuthorizationServerInfoResponse(["aud"]);
+    getAuthorizationServerInfoMock.mockResolvedValue(response);
+    res = {
+      redirect: jest.fn(),
+    };
+
+    req.query = {
+      state: "fake_state",
+      client_id: "clientId123",
+      redirect_uri: "http://localhost:8080/oauth/redirect",
+    };
+
+    await authorizeHandler(
+      redirect_uri,
+      logger,
+      issuer,
+      dynamoClient,
+      oktaClient,
+      mockSlugHelper,
+      api_category,
+      "OAuthRequestsV2",
+      "Clients",
+      "idp1",
+      req,
+      res,
+      next
+    );
+    expect(res.redirect).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+  });
+});
+
+describe("Unauthorized Client", () => {
   it("Invalid client in request, local client config, mimic no db table", async () => {
     dynamoClient = buildFakeDynamoClient({
       client_id: "clientId123xxxx",
@@ -750,50 +797,5 @@ describe("authorizeHandler", () => {
       { client_id: "clientId123" },
       "Clients"
     );
-  });
-
-  it("Error on save to dynamo", async () => {
-    dynamoClient.savePayloadToDynamo = jest.fn().mockImplementation(() => {
-      return new Promise((resolve, reject) => {
-        // It's unclear whether this should resolve with a full records or just
-        // the identity field but thus far it has been irrelevant to the
-        // functional testing of the oauth-proxy.
-        reject({
-          error: "bad_things_error",
-          error_description: "Bad things happen",
-        });
-      });
-    });
-
-    let response = buildFakeGetAuthorizationServerInfoResponse(["aud"]);
-    getAuthorizationServerInfoMock.mockResolvedValue(response);
-    res = {
-      redirect: jest.fn(),
-    };
-
-    req.query = {
-      state: "fake_state",
-      client_id: "clientId123",
-      redirect_uri: "http://localhost:8080/oauth/redirect",
-    };
-
-    await authorizeHandler(
-      redirect_uri,
-      logger,
-      issuer,
-      dynamoClient,
-      oktaClient,
-      mockSlugHelper,
-      api_category,
-      "OAuthRequestsV2",
-      "Clients",
-      "idp1",
-      req,
-      res,
-      next
-    );
-    expect(res.redirect).not.toHaveBeenCalled();
-    expect(next).toHaveBeenCalled();
-    expect(logger.error).toHaveBeenCalled();
   });
 });

--- a/oauth-proxy/tests/authorizeHandler.test.js
+++ b/oauth-proxy/tests/authorizeHandler.test.js
@@ -655,14 +655,17 @@ describe("Server Error", () => {
       req,
       res,
       next
-    );
+    )
+      .then(() => {
+        fail("Error should bubble up");
+      })
+      .catch((err) => {
+        expect(err.status).toBe(500);
+      });
 
     expect(logger.error).toHaveBeenCalledWith(
       "Unable to get the authorization server."
     );
-    expect(next).toHaveBeenCalledWith({
-      status: 500,
-    });
   });
 
   it("Error on save to dynamo", async () => {

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -812,4 +812,74 @@ describe("OpenID Connect Conformance", () => {
         expect(err.response.statusText).toEqual("Unauthorized");
       });
   });
+
+  it("returns an OIDC conformant status 302 on valid authorization request", async () => {
+    // By setting the maxRedirects to 0, the redirect uri can be checked without going through the whole flow
+    await axios
+      .get("http://localhost:9090/testServer/authorization", {
+        params: {
+          client_id: "clientId123",
+          scope: "scope",
+          response_type: "code",
+          redirect_uri: "http://localhost:8080/oauth/redirect",
+          state: "state",
+        },
+        maxRedirects: 0,
+      })
+      .then(() => fail("maxRedirects should be exceeded"))
+      .catch((err) => {
+        expect(err.response.config.url).toBe(
+          "http://localhost:9090/testServer/authorization"
+        );
+        expect(err.response.status).toEqual(302);
+      });
+  });
+
+  it("returns an OIDC conformant status 302 with invalid_request error on authorization request with missing state.", async () => {
+    // This test will be changed to redirect when proper RFC compliance is added
+    await axios
+      .get("http://localhost:9090/testServer/authorization", {
+        params: {
+          client_id: "clientId123",
+          scope: "scope",
+          response_type: "code",
+          state: "state"
+        },
+        maxRedirects: 0,
+      })
+      .then(() => fail("maxRedirects should be exceeded"))
+      .catch((err) => {
+        expect(err.response.data.error).toBe(
+          "invalid_client"
+        );
+        expect(err.response.data.error_description).toBe(
+          "There was no redirect URI specified by the application."
+        );
+        expect(err.response.status).toEqual(400);
+      });
+  });
+
+  it("OIDC conformant notification to resource owner on authorization request with missing redirect.", async () => {
+    // This test will be changed to redirect when proper RFC compliance is added
+    await axios
+      .get("http://localhost:9090/testServer/authorization", {
+        params: {
+          client_id: "clientId123",
+          scope: "scope",
+          response_type: "code",
+          redirect_uri: "http://localhost:8080/oauth/redirect",
+        },
+        maxRedirects: 0,
+      })
+      .then(() => fail("maxRedirects should be exceeded"))
+      .catch((err) => {
+        expect(err.response.data.error).toBe(
+          "invalid_request"
+        );
+        expect(err.response.data.error_description).toBe(
+          "State parameter required"
+        );
+        expect(err.response.status).toEqual(400);
+      });
+  });
 });

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -843,15 +843,13 @@ describe("OpenID Connect Conformance", () => {
           client_id: "clientId123",
           scope: "scope",
           response_type: "code",
-          state: "state"
+          state: "state",
         },
         maxRedirects: 0,
       })
       .then(() => fail("maxRedirects should be exceeded"))
       .catch((err) => {
-        expect(err.response.data.error).toBe(
-          "invalid_client"
-        );
+        expect(err.response.data.error).toBe("invalid_client");
         expect(err.response.data.error_description).toBe(
           "There was no redirect URI specified by the application."
         );
@@ -873,9 +871,7 @@ describe("OpenID Connect Conformance", () => {
       })
       .then(() => fail("maxRedirects should be exceeded"))
       .catch((err) => {
-        expect(err.response.data.error).toBe(
-          "invalid_request"
-        );
+        expect(err.response.data.error).toBe("invalid_request");
         expect(err.response.data.error_description).toBe(
           "State parameter required"
         );


### PR DESCRIPTION
# Description

Precursor to creating RFC compliant authorize error handling. Refactor previous error handling to eliminate code smells. Reduce nested if statements. 

# TODO

- [x] Organize Unit Tests by Relationship
- [x] Local vs Auth Client Validation broken into helper method
- [x] checks return objects instead of throwing errors

There are no e2e tests for the authorization endpoint. Add the following:
- [x] Happy Path
- [x] invalid_request missing state | will eventually redirect
- [x] invalid_request missing redirect | notify resource owner

# Tests

- [x] Regression Tests Run
- [x] Unit Tests Pass
## Local Authorize Tests

## Confirm Happy Path is working.

- Make Authorization request.
- client_store = local
- client_store has redirect `localhost:8080/redirect`

### Expected results

- [x] Redirect to authorization server 

## Confirm Client Redirect Miss is working.

- Make Authorization request.
- client_store = local
- client_store does not have redirect `localhost:8080/redirect`

expected results

- [x] expected json
```json
{
    "error":	"invalid_client",
    "error_description": "The redirect URI specified by the application does not match any of the registered redirect URIs. Erroneous redirect URI: http://localhost:8080/redirect"
}
```

## Client miss in client_store

- Make Authorization request.
- client_store = local
- specified client not in client_store

expected results

- [x] expected json
```json
{
    "error": "invalid_client",
    "error_description": "Invalid client for the authorization path",
}
```

## No Clients in client_store

- Make Authorization request.
- client_store = local
- force dynamo error 

expected results

- [x] expected json
```json
{
    "error": "invalid_client",
    "error_description": "The client specified by the application is not valid."
}
```

## No Okta Redirect URI

- Make Authorization request.
- client_store = null
- redirect uri not registered with okta

expected results

- [x] expected json
```json
{
    "error": "invalid_client",
    "error_description": "The redirect URI specified by the application does not match any of the registered redirect URIs. Erroneous redirect URI: ${client_redirect}"
}
```

## No Okta Client Id

- Make Authorization request.
- client_store = null
- client id not registered with okta

expected results

- [x] expected json
```json
{
    "error": "invalid_client",
    "error_description": "The client specified by the application is not valid.",
}
```
