### PR TITLE
RFC compliant authorize error handling

### DIFF
--- a/oauth-proxy/oauthHandlers/authorizeHandler.js
+++ b/oauth-proxy/oauthHandlers/authorizeHandler.js
@@ -123,7 +123,7 @@ const authorizeHandler = async (
 /**
  * Checks for valid authorization parameters.
  *
- * @returns {Promise<{valid: boolean, error_description: string, error: string}>}
+ * @returns {Promise<{valid: boolean, error?: string, error_description?: string}>}
  */
 const checkParameters = async (state, aud, issuer, logger, oktaClient) => {
   if (!state) {
@@ -165,7 +165,7 @@ const checkParameters = async (state, aud, issuer, logger, oktaClient) => {
 /**
  * Checks for authorization server or local database for valid client.
  *
- * @returns {Promise<{valid: boolean, error_description: string}>}
+ * @returns {Promise<{valid: boolean, error?: string, error_description?: string}>}
  */
 const validateClient = async (
   logger,
@@ -206,7 +206,7 @@ const validateClient = async (
 /**
  * Checks for authorization local database for valid client.
  *
- * @returns {Promise<{valid: boolean, error_description: string}>}
+ * @returns {Promise<{valid: boolean, error?: string, error_description?: string}>}
  */
 const localValidateClient = async (
   logger,
@@ -256,7 +256,7 @@ const localValidateClient = async (
 /**
  * Checks for authorization server for valid client.
  *
- * @returns {Promise<{valid: boolean, error_description: string}>}
+ * @returns {Promise<{valid: boolean, error?: string, error_description?: string}>}
  */
 const serverValidateClient = async (
   oktaClient,
@@ -298,6 +298,8 @@ const serverValidateClient = async (
 
 /**
  * Builds errors to be sent to client's redirect uri.
+ *
+ * @returns {module:url.URL}
  */
 const buildRedirectErrorUri = (err, redirect_uri) => {
   let uri = new URL(redirect_uri);
@@ -305,4 +307,5 @@ const buildRedirectErrorUri = (err, redirect_uri) => {
   uri.searchParams.append("error_description", err.error_description);
   return uri;
 };
+
 module.exports = authorizeHandler;

--- a/oauth-proxy/oauthHandlers/authorizeHandler.js
+++ b/oauth-proxy/oauthHandlers/authorizeHandler.js
@@ -176,8 +176,8 @@ const validateClient = async (
   oktaClient,
   app_category
 ) => {
-  if (!client_id) {
-    logger.error("No client_id present.");
+  if (!client_id || !/^\w+$/.test(client_id)) {
+    logger.error("No valid client_id was found.");
     return {
       valid: false,
       error: "unauthorized_client",
@@ -187,7 +187,7 @@ const validateClient = async (
   }
 
   if (!client_redirect) {
-    logger.error("No redirect_uri present.");
+    logger.error("No valid redirect_uri was found.");
     return {
       valid: false,
       error: "invalid_request",

--- a/oauth-proxy/oauthHandlers/authorizeHandler.js
+++ b/oauth-proxy/oauthHandlers/authorizeHandler.js
@@ -48,18 +48,7 @@ const authorizeHandler = async (
     app_category
   );
 
-  if (!validationError.valid && validationError.redirect) {
-    let uri = buildRedirectErrorUri(
-      {
-        error: validationError.error,
-        error_description: validationError.error_description,
-      },
-      client_redirect
-    );
-    return res.redirect(uri.toString());
-  }
-
-  if (!validationError.valid && !validationError.redirect) {
+  if (!validationError.valid) {
     res.status(400).json({
       error: validationError.error,
       error_description: validationError.error_description,
@@ -75,7 +64,7 @@ const authorizeHandler = async (
     oktaClient
   );
 
-  if (!missingParameters.valid && missingParameters.redirect) {
+  if (!missingParameters.valid) {
     let uri = buildRedirectErrorUri(
       {
         error: missingParameters.error,
@@ -84,14 +73,6 @@ const authorizeHandler = async (
       client_redirect
     );
     return res.redirect(uri.toString());
-  }
-
-  if (!missingParameters.valid && !missingParameters.redirect) {
-    res.status(400).json({
-      error: missingParameters.error,
-      error_description: missingParameters.error_description,
-    });
-    return next();
   }
 
   let internal_state = uuidv4();
@@ -149,7 +130,6 @@ const checkParameters = async (state, aud, issuer, logger, oktaClient) => {
     logger.error("No valid state parameter was found.");
     return {
       valid: false,
-      redirect: true,
       error: "invalid_request",
       error_description: "State parameter required",
     };
@@ -200,7 +180,6 @@ const validateClient = async (
     logger.error("No valid redirect_uri was found.");
     return {
       valid: false,
-      redirect: false,
       error: "invalid_request",
       error_description:
         "There was no redirect URI specified by the application.",
@@ -248,7 +227,6 @@ const localValidateClient = async (
     } else {
       return {
         valid: false,
-        redirect: true,
         error: "unauthorized_client",
         error_description:
           "The client specified by the application is not valid.",
@@ -257,7 +235,6 @@ const localValidateClient = async (
     if (!clientInfo.redirect_uris.values.includes(client_redirect)) {
       return {
         valid: false,
-        redirect: false,
         error: "invalid_request",
         error_description:
           "The redirect URI specified by the application does not match any of the " +
@@ -268,7 +245,6 @@ const localValidateClient = async (
     logger.error("Failed to retrieve client info from Dynamo DB.", err);
     return {
       valid: false,
-      redirect: true,
       error: "unauthorized_client",
       error_description:
         "The client specified by the application is not valid.",
@@ -301,7 +277,6 @@ const serverValidateClient = async (
 
     return {
       valid: false,
-      redirect: true,
       error: "unauthorized_client",
       error_description:
         "The client specified by the application is not valid.",
@@ -312,7 +287,6 @@ const serverValidateClient = async (
   ) {
     return {
       valid: false,
-      redirect: false,
       error: "invalid_request",
       error_description:
         "The redirect URI specified by the application does not match any of the " +

--- a/oauth-proxy/oauthHandlers/authorizeHandler.js
+++ b/oauth-proxy/oauthHandlers/authorizeHandler.js
@@ -35,6 +35,7 @@ const authorizeHandler = async (
   res,
   next
 ) => {
+  // implement rfc compliant error handling ...
   loginBegin.inc();
   const { state, client_id, aud, redirect_uri: client_redirect } = req.query;
 

--- a/oauth-proxy/tests/authorizeHandler.test.js
+++ b/oauth-proxy/tests/authorizeHandler.test.js
@@ -539,8 +539,12 @@ describe("Invalid Request", () => {
   });
 
   it("State is empty, redirects", async () => {
+    let response = buildFakeGetAuthorizationServerInfoResponse(["aud"]);
+    getAuthorizationServerInfoMock.mockResolvedValue(response);
+
     req.query = {
       state: null,
+      client_id: "clientId123",
       redirect_uri: "http://localhost:8080/oauth/redirect",
     };
     await authorizeHandler(

--- a/oauth-proxy/tests/authorizeHandler.test.js
+++ b/oauth-proxy/tests/authorizeHandler.test.js
@@ -529,7 +529,7 @@ describe("Invalid Request", () => {
     expect(res.redirect).toHaveBeenCalledWith(
       buildRedirectErrorUri(
         {
-          error: "invalid_client",
+          error: "unauthorized_client",
           error_description:
             "The client specified by the application is not valid.",
         },
@@ -837,7 +837,7 @@ describe("Unauthorized Client", () => {
     expect(res.redirect).toHaveBeenCalledWith(
       buildRedirectErrorUri(
         {
-          error: "invalid_client",
+          error: "unauthorized_client",
           error_description:
             "The client specified by the application is not valid.",
         },
@@ -891,7 +891,7 @@ describe("Unauthorized Client", () => {
     expect(res.redirect).toHaveBeenCalledWith(
       buildRedirectErrorUri(
         {
-          error: "invalid_client",
+          error: "unauthorized_client",
           error_description:
             "The client specified by the application is not valid.",
         },

--- a/oauth-proxy/tests/authorizeHandler.test.js
+++ b/oauth-proxy/tests/authorizeHandler.test.js
@@ -460,7 +460,7 @@ describe("Invalid Request", () => {
 
     expect(res.statusCode).toEqual(400);
     expect(res.json).toHaveBeenCalledWith({
-      error: "invalid_client",
+      error: "invalid_request",
       error_description:
         "There was no redirect URI specified by the application.",
     });
@@ -636,7 +636,7 @@ describe("Invalid Request", () => {
         "http://localhost:8080/oauth/invalid/redirect"
       ),
     });
-    expect(next).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
     expect(res.redirect).not.toHaveBeenCalled();
   });
 
@@ -678,7 +678,7 @@ describe("Invalid Request", () => {
         "http://localhost:8080/oauth/invalid/redirect"
       ),
     });
-    expect(next).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
     expect(res.redirect).not.toHaveBeenCalled();
   });
 });

--- a/oauth-proxy/tests/authorizeHandler.test.js
+++ b/oauth-proxy/tests/authorizeHandler.test.js
@@ -592,7 +592,6 @@ describe("Invalid Request", () => {
       res,
       next
     );
-
     expect(res.statusCode).toEqual(400);
     expect(res.json).toHaveBeenCalledWith({
       error: "invalid_request",
@@ -600,6 +599,35 @@ describe("Invalid Request", () => {
     });
   });
 
+  it("Bad redirect_uri and missing state", async () => {
+    req.query = {
+      client_id: "clientId123",
+      redirect_uri: "https://www.example.bad.com",
+    };
+
+    await authorizeHandler(
+      redirect_uri,
+      logger,
+      issuer,
+      dynamoClient,
+      oktaClient,
+      mockSlugHelper,
+      api_category,
+      "OAuthRequestsV2",
+      "Clients",
+      "idp1",
+      req,
+      res,
+      next
+    );
+
+    expect(res.redirect).not.toHaveBeenCalled();
+    expect(res.statusCode).toEqual(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "invalid_request",
+      error_description: badRedirectMessage("https://www.example.bad.com"),
+    });
+  });
   it("Invalid path in request", async () => {
     dynamoClient = buildFakeDynamoClient({
       client_id: "clientId123",

--- a/oauth-proxy/tests/authorizeHandler.test.js
+++ b/oauth-proxy/tests/authorizeHandler.test.js
@@ -442,6 +442,10 @@ describe("Invalid Request", () => {
   });
 
   it("No client_redirect, returns 400", async () => {
+    req.query = {
+      client_id: "clientId123",
+    };
+
     await authorizeHandler(
       redirect_uri,
       logger,

--- a/oauth-proxy/tests/authorizeHandler.test.js
+++ b/oauth-proxy/tests/authorizeHandler.test.js
@@ -526,16 +526,13 @@ describe("Invalid Request", () => {
       next
     );
 
-    expect(res.redirect).toHaveBeenCalledWith(
-      buildRedirectErrorUri(
-        {
-          error: "unauthorized_client",
-          error_description:
-            "The client specified by the application is not valid.",
-        },
-        "http://localhost:8080/oauth/redirect"
-      ).toString()
-    );
+    expect(res.redirect).not.toHaveBeenCalled();
+    expect(res.statusCode).toEqual(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "unauthorized_client",
+      error_description:
+        "The client specified by the application is not valid.",
+    });
   });
 
   it("State is empty, redirects", async () => {
@@ -834,16 +831,13 @@ describe("Unauthorized Client", () => {
       next
     );
 
-    expect(res.redirect).toHaveBeenCalledWith(
-      buildRedirectErrorUri(
-        {
-          error: "unauthorized_client",
-          error_description:
-            "The client specified by the application is not valid.",
-        },
-        "http://localhost:8080/oauth/redirect"
-      ).toString()
-    );
+    expect(res.redirect).not.toHaveBeenCalled();
+    expect(res.statusCode).toEqual(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "unauthorized_client",
+      error_description:
+        "The client specified by the application is not valid.",
+    });
     expect(dynamoClient.getPayloadFromDynamo).toHaveBeenCalledWith(
       { client_id: "clientId123" },
       "Clients"
@@ -888,16 +882,13 @@ describe("Unauthorized Client", () => {
       next
     );
 
-    expect(res.redirect).toHaveBeenCalledWith(
-      buildRedirectErrorUri(
-        {
-          error: "unauthorized_client",
-          error_description:
-            "The client specified by the application is not valid.",
-        },
-        "http://localhost:8080/oauth/redirect"
-      ).toString()
-    );
+    expect(res.redirect).not.toHaveBeenCalled();
+    expect(res.statusCode).toEqual(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "unauthorized_client",
+      error_description:
+        "The client specified by the application is not valid.",
+    });
     expect(dynamoClient.getPayloadFromDynamo).toHaveBeenCalledWith(
       { client_id: "clientId123" },
       "Clients"

--- a/oauth-proxy/tests/authorizeHandler.test.js
+++ b/oauth-proxy/tests/authorizeHandler.test.js
@@ -367,6 +367,38 @@ describe("Invalid Request", () => {
     expect(next).toHaveBeenCalled();
   });
 
+  it("Invalid client_id results in 400", async () => {
+    let response = buildFakeGetAuthorizationServerInfoResponse(["aud"]);
+    getAuthorizationServerInfoMock.mockResolvedValue(response);
+
+    req.query = {
+      client_id: "a.b",
+    };
+
+    await authorizeHandler(
+      redirect_uri,
+      logger,
+      issuer,
+      dynamoClient,
+      oktaClient,
+      mockSlugHelper,
+      api_category,
+      "OAuthRequestsV2",
+      "Clients",
+      "idp1",
+      req,
+      res,
+      next
+    );
+    expect(res.statusCode).toEqual(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "unauthorized_client",
+      error_description:
+        "The client specified by the application is not valid.",
+    });
+    expect(next).toHaveBeenCalled();
+  });
+
   it("Verify that undefined redirect_uri results in 400", async () => {
     let response = buildFakeGetAuthorizationServerInfoResponse(["aud"]);
     getAuthorizationServerInfoMock.mockResolvedValue(response);

--- a/oauth-proxy/tests/authorizeHandler.test.js
+++ b/oauth-proxy/tests/authorizeHandler.test.js
@@ -684,6 +684,7 @@ describe("Invalid Request", () => {
 });
 
 describe("Server Error", () => {
+  //I am unsure of this functionality??
   it("getAuthorizationServerInfo Error, return 500", async () => {
     getAuthorizationServerInfoMock.mockRejectedValue({ error: "fakeError" });
 

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -862,7 +862,7 @@ describe("OpenID Connect Conformance", () => {
         params: {
           client_id: "clientId123",
           scope: "scope",
-          response_type: "code", 
+          response_type: "code",
         },
         maxRedirects: 0,
       })
@@ -882,8 +882,8 @@ describe("OpenID Connect Conformance", () => {
         params: {
           client_id: "clientId123",
           scope: "scope",
-          response_type: "code", 
-          redirect_uri: "http://localhost:8080/invalid/oauth/redirect"
+          response_type: "code",
+          redirect_uri: "http://localhost:8080/invalid/oauth/redirect",
         },
         maxRedirects: 0,
       })
@@ -891,8 +891,8 @@ describe("OpenID Connect Conformance", () => {
       .catch((err) => {
         expect(err.response.data.error).toBe("invalid_request");
         expect(err.response.data.error_description).toBe(
-          "The redirect URI specified by the application does not match any of the registered redirect URIs."
-          +" Erroneous redirect URI: http://localhost:8080/invalid/oauth/redirect"
+          "The redirect URI specified by the application does not match any of the registered redirect URIs." +
+            " Erroneous redirect URI: http://localhost:8080/invalid/oauth/redirect"
         );
         expect(err.response.status).toEqual(400);
       });

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -843,18 +843,14 @@ describe("OpenID Connect Conformance", () => {
           client_id: "clientId123",
           scope: "scope",
           response_type: "code",
-          state: "state",
+          redirect_uri: "http://localhost:8080/oauth/redirect"
         },
         maxRedirects: 0,
       })
       .then(() => fail("maxRedirects should be exceeded"))
       .catch((err) => {
-        expect(err.response.config.url).toBe(
-          "http://localhost:8080/oauth/redirect"
-        );
-        expect(err.response.config.params.error).toBe("invalid_request");
-        expect(err.response.config.params.error).toBe(
-          "State parameter required"
+        expect(err.response.data).toBe(
+          "Found. Redirecting to http://localhost:8080/oauth/redirect?error=invalid_request&error_description=State+parameter+required"
         );
         expect(err.response.status).toEqual(302);
       });
@@ -867,7 +863,7 @@ describe("OpenID Connect Conformance", () => {
           client_id: "clientId123",
           scope: "scope",
           response_type: "code",
-          redirect_uri: "http://localhost:8080/oauth/redirect",
+          state: "state",
         },
         maxRedirects: 0,
       })

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -849,16 +849,20 @@ describe("OpenID Connect Conformance", () => {
       })
       .then(() => fail("maxRedirects should be exceeded"))
       .catch((err) => {
-        expect(err.response.data.error).toBe("invalid_client");
-        expect(err.response.data.error_description).toBe(
-          "There was no redirect URI specified by the application."
+        expect(err.response.config.url).toBe(
+          "http://localhost:8080/oauth/redirect"
         );
-        expect(err.response.status).toEqual(400);
+        expect(err.response.config.params.error).toBe(
+          "invalid_request"
+        );
+        expect(err.response.config.params.error).toBe(
+          "State parameter required"
+        );
+        expect(err.response.status).toEqual(302);
       });
   });
 
   it("OIDC conformant notification to resource owner on authorization request with missing redirect.", async () => {
-    // This test will be changed to redirect when proper RFC compliance is added
     await axios
       .get("http://localhost:9090/testServer/authorization", {
         params: {

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -856,14 +856,34 @@ describe("OpenID Connect Conformance", () => {
       });
   });
 
-  it("OIDC conformant notification to resource owner on authorization request with missing redirect.", async () => {
+  it("OIDC conformant notification to resource owner on authorization request with missing state and redirect.", async () => {
     await axios
       .get("http://localhost:9090/testServer/authorization", {
         params: {
           client_id: "clientId123",
           scope: "scope",
-          response_type: "code",
-          state: "state",
+          response_type: "code", 
+        },
+        maxRedirects: 0,
+      })
+      .then(() => fail("maxRedirects should be exceeded"))
+      .catch((err) => {
+        expect(err.response.data.error).toBe("invalid_request");
+        expect(err.response.data.error_description).toBe(
+          "There was no redirect URI specified by the application."
+        );
+        expect(err.response.status).toEqual(400);
+      });
+  });
+
+  it("OIDC conformant notification to resource owner on authorization request with missing state and invalid redirect.", async () => {
+    await axios
+      .get("http://localhost:9090/testServer/authorization", {
+        params: {
+          client_id: "clientId123",
+          scope: "scope",
+          response_type: "code", 
+          redirect_uri: "http://localhost:8080/invalid/oauth/redirect"
         },
         maxRedirects: 0,
       })

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -843,7 +843,7 @@ describe("OpenID Connect Conformance", () => {
           client_id: "clientId123",
           scope: "scope",
           response_type: "code",
-          redirect_uri: "http://localhost:8080/oauth/redirect"
+          redirect_uri: "http://localhost:8080/oauth/redirect",
         },
         maxRedirects: 0,
       })

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -871,7 +871,7 @@ describe("OpenID Connect Conformance", () => {
       .catch((err) => {
         expect(err.response.data.error).toBe("invalid_request");
         expect(err.response.data.error_description).toBe(
-          "State parameter required"
+          "There was no redirect URI specified by the application."
         );
         expect(err.response.status).toEqual(400);
       });

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -891,7 +891,8 @@ describe("OpenID Connect Conformance", () => {
       .catch((err) => {
         expect(err.response.data.error).toBe("invalid_request");
         expect(err.response.data.error_description).toBe(
-          "There was no redirect URI specified by the application."
+          "The redirect URI specified by the application does not match any of the registered redirect URIs."
+          +" Erroneous redirect URI: http://localhost:8080/invalid/oauth/redirect"
         );
         expect(err.response.status).toEqual(400);
       });

--- a/oauth-proxy/tests/e2e.test.js
+++ b/oauth-proxy/tests/e2e.test.js
@@ -852,9 +852,7 @@ describe("OpenID Connect Conformance", () => {
         expect(err.response.config.url).toBe(
           "http://localhost:8080/oauth/redirect"
         );
-        expect(err.response.config.params.error).toBe(
-          "invalid_request"
-        );
+        expect(err.response.config.params.error).toBe("invalid_request");
         expect(err.response.config.params.error).toBe(
           "State parameter required"
         );

--- a/oauth-proxy/tests/scripts/other_tests.sh
+++ b/oauth-proxy/tests/scripts/other_tests.sh
@@ -158,7 +158,7 @@ curl -s \
   "$DIR"/assertions.sh --expect-status --status="$(cat "$curl_status")" --expected-status=400
 track_result
 
-"$DIR"/assertions.sh --expect-json --json="$(cat "$curl_body")" --expected-json='{"error": "invalid_client", "error_description": "There was no redirect URI specified by the application."}'
+"$DIR"/assertions.sh --expect-json --json="$(cat "$curl_body")" --expected-json='{"error": "invalid_request", "error_description": "There was no redirect URI specified by the application."}'
 track_result
 
 echo -e "\tRunning ... Authorize Handler with undefined redirect_uri"
@@ -171,7 +171,7 @@ curl -s \
   "$DIR"/assertions.sh --expect-status --status="$(cat "$curl_status")" --expected-status=400
 track_result
 
-"$DIR"/assertions.sh --expect-json --json="$(cat "$curl_body")" --expected-json='{"error": "invalid_client", "error_description": "There was no redirect URI specified by the application."}'
+"$DIR"/assertions.sh --expect-json --json="$(cat "$curl_body")" --expected-json='{"error": "invalid_request", "error_description": "There was no redirect URI specified by the application."}'
 track_result
 
 echo -e "\tRunning ... Redirect Handler without a redirect_url that can be looked up"

--- a/oauth-proxy/tests/scripts/other_tests.sh
+++ b/oauth-proxy/tests/scripts/other_tests.sh
@@ -142,14 +142,10 @@ then
 fi
 
 curl -s \
-  -w "%{http_code}" \
-  -o "$curl_body" \
+  -Ls -w "%{url_effective}" -o /dev/null \
   "$HOST/authorization?client_id=$CLIENT_ID&scope=$SCOPE&response_type=code&redirect_uri=$REDIRECT_URI&aud=default" > "$curl_status"
 
-"$DIR"/assertions.sh --expect-status --status="$(cat "$curl_status")" --expected-status=400
-track_result
-
-"$DIR"/assertions.sh --expect-json --json="$(cat "$curl_body")" --expected-json='{"error": "invalid_request", "error_description": "State parameter required"}'
+"$DIR"/assertions.sh --expect-status --status="$(cat "$curl_status")" --expected-status="$REDIRECT_URI?error=invalid_request&error_description=State+parameter+required"
 track_result
 
 echo -e "\tRunning ... Authorize Handler with no redirect_uri"


### PR DESCRIPTION
# Description

Authorize Handler should return RFC compliant errors,

```
If the request fails due to a missing, invalid, or mismatching
redirection URI, or if the client identifier is missing or invalid,
the authorization server SHOULD inform the resource owner of the
error and MUST NOT automatically redirect the user-agent to the
invalid redirection URI.

If the resource owner denies the access request or if the request
fails for reasons other than a missing or invalid redirection URI,
the authorization server informs the client by adding the following
parameters to the query component of the redirection URI using the
"application/x-www-form-urlencoded" format, per Appendix B:
...
```

In the case of the Oauth-Proxy

- Issues with the redirect_uri can continue to result in an error page rendered by the oauth-proxy.
- Other authorization errors should be sent to the redirect_uri. ex.
```http
https://example-app.com/cb?error=invalid_request&error_description=blah blah blah
```

## Different error handling scenarios

**invalid_request**
- no state

**invalid_request cannot be sent back to redirect uri**
- no Redirect URI
- Erronous redirect local | was previously invalid_client
- Erronous redirect Okta | was previously invalid_client

**server_error Oauth Proxy**
- could not pull from dynamodb | returns unauthorized_client
- could not save redirect | bubbles up

**server_error Okta**
- could not get auth server | bubbles up

**unauthorized_client**
- bad client local | does not redirect
- could not get okta app | does not redirect

# TODO

Modify unit tests to check for errors on the following scenarios:
- [x] no state
- [x] could not pull from dynamodb
- [x] could not save redirect
- [x] could not get auth server
- [x] could not get okta app
- [x] bad client 
- [x] add error and error_description checks on 400 tests

Regression Tests
- [x] Add integration test for no Redirect URI
- [x] Modify no state integration test to check for redirect

Integration Tests
- [x] modify missing state integration test to check for redirect

# Tests

## Regression tests pass.
**Happy Path**
- [x]  Pass

**No Redirect**
- [x] Pass
```json
{
  "error": "invalid_request",
  "error_description" : "There was no redirect URI specified by the application."
}
```
was previously invalid_client

**No State**
- [x] Pass
```json
{
  "error": "invalid_request",
  "error_description" : "State parameter required"
}
```
## Local Happy Path
- [x] Redirect to saml-proxy

## Erroneous Redirect
**local**
- [x] 400 Error
- [x] json
```json
{
  "error": "invalid_request ",
  "error_description": "The redirect URI specified by the application does not match any of the registered redirect URIs. Erroneous redirect URI: {URI}"
}
```
**auth server**
- [x] 400 Error
- [x] json
```json
{
  "error": "invalid_request ",
  "error_description": "The redirect URI specified by the application does not match any of the registered redirect URIs. Erroneous redirect URI: {URI}"
}
```

This use to return a invalid_client. Should it still?

## Server Errors
**Could not pull from dynamo**
- [x] 400
- [x] error = unauthorized_client
- [x] error_description = "The client specified by the application is not valid."

**Could not save to dynamo**
- [x] bubbles up.

**Could not get auth server when checking for aud**
- [x] bubbles up.

## Invalid Client

**Could not get okta app**
- [x] 400
- [x] error = unauthorized_client
- [x] error_description = "The client specified by the application is not valid."

**Bad Client Local** 
- [x] 400
- [x] error = unauthorized_client
- [x] error_description = "The client specified by the application is not valid."