### PR TITLE
add access token and iss to oauth requests v2

### DIFF
--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClient.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClient.js
@@ -20,7 +20,6 @@ class TokenHandlerClient {
     this.res = res;
     this.next = next;
   }
-  // first commit!
   async handleToken() {
     let tokens;
     try {

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClient.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClient.js
@@ -20,6 +20,7 @@ class TokenHandlerClient {
     this.res = res;
     this.next = next;
   }
+  // first commit!
   async handleToken() {
     let tokens;
     try {

--- a/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
+++ b/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
@@ -5,6 +5,7 @@ const {
   createFakeConfig,
 } = require("../testUtils");
 const MockExpressRequest = require("mock-express-request");
+const { Issuer } = require("openid-client");
 const {
   SaveDocumentStateStrategy,
 } = require("../../oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy");
@@ -75,7 +76,8 @@ describe("saveDocumentStateStrategy tests", () => {
       req,
       logger,
       dynamoClient,
-      config
+      config,
+      new Issuer({ issuer: "issuer" })
     );
     strategy.saveDocumentToDynamo(document, tokens);
     expect(logger.error).not.toHaveBeenCalled();
@@ -93,7 +95,8 @@ describe("saveDocumentStateStrategy tests", () => {
       req,
       logger,
       dynamoClient,
-      config
+      config,
+      new Issuer({ issuer: "issuer" })
     );
     strategy.saveDocumentToDynamo(document, tokens);
     expect(logger.error).not.toHaveBeenCalled();
@@ -113,7 +116,8 @@ describe("saveDocumentStateStrategy tests", () => {
       req,
       logger,
       dynamoClient,
-      config
+      config,
+      new Issuer({ issuer: "issuer" })
     );
     strategy.saveDocumentToDynamo(document, tokens);
     expect(dynamoClient.updateToDynamo).toHaveBeenCalledWith(
@@ -122,6 +126,8 @@ describe("saveDocumentStateStrategy tests", () => {
         expires_on: 3628800,
         refresh_token:
           "9b4dba523ad0a7e323452871556d691787cd90c6fe959b040c5864979db5e337",
+        access_token: tokens.access_token,
+        iss: "issuer",
       },
       "OAuthRequestsV2"
     );
@@ -146,7 +152,8 @@ describe("saveDocumentStateStrategy tests", () => {
       req,
       logger,
       dynamoClient,
-      config
+      config,
+      new Issuer({ issuer: "issuer" })
     );
     strategy.saveDocumentToDynamo(document, tokens);
     expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalledWith(
@@ -157,6 +164,8 @@ describe("saveDocumentStateStrategy tests", () => {
         refresh_token:
           "9b4dba523ad0a7e323452871556d691787cd90c6fe959b040c5864979db5e337",
         state: "abc123",
+        access_token: tokens.access_token,
+        iss: "issuer",
       },
       "OAuthRequestsV2"
     );
@@ -174,7 +183,8 @@ describe("saveDocumentStateStrategy tests", () => {
       req,
       logger,
       dynamoClient,
-      config
+      config,
+      new Issuer({ issuer: "issuer" })
     );
     strategy.saveDocumentToDynamo(document, tokens);
     expect(logger.error).not.toHaveBeenCalled();
@@ -189,7 +199,8 @@ describe("saveDocumentStateStrategy tests", () => {
       req,
       logger,
       dynamoClient,
-      config
+      config,
+      new Issuer({ issuer: "issuer" })
     );
     strategy.saveDocumentToDynamo(document, tokens);
     expect(logger.error).toHaveBeenCalled();


### PR DESCRIPTION
# Description

Add Access Token and ISS to OAuthRequestsV2 on Token requests.

# TODO

- [ ] Create PR to Add `oauth_access_token_index` to `OAuthRequestsV2`
    - [ ] Add `oauth_access_token_index` to `OAuthRequestsV2` in `dynamo_schema.js`
- [ ] Add logic to store access_token in the tokenHandlerClient.
- [ ] Unit Tests
- [ ] Manual Tests

# Tests

## Happy Path Okta

**Test Steps**

- Go through Oauth flow on default issuer.

**Expected Results**

```sh
aws dynamodb scan --table-name OAuthRequestsV2 --endpoint-url http://localhost:8080
```

should return following fields

- [ ] code
- [ ] internal_state
- [ ] redirect_uri
- [ ] state
- [ ] expires_on
- [ ] access_token
- [ ] iss

## Happy Path "IAM"

**Test Steps**

- Go through Oauth flow on IAM issuer.

**Expected Results**

```sh
aws dynamodb scan --table-name OAuthRequestsV2 --endpoint-url http://localhost:8080
```

should return following fields

- [ ] code
- [ ] internal_state
- [ ] redirect_uri
- [ ] state
- [ ] expires_on
- [ ] access_token
- [ ] iss

## Refresh

**Test Steps**

- Go through refresh flow on default issuer.

**Expected Results**

```sh
aws dynamodb scan --table-name OAuthRequestsV2 --endpoint-url http://localhost:8080
```

should return following fields

- [ ] code
- [ ] internal_state
- [ ] redirect_uri
- [ ] state
- [ ] expires_on
- [ ] refresh_token
- [ ] iss