### PR TITLE
Saves access-token and issuer on Token Request

### DIFF
--- a/oauth-proxy/README.md
+++ b/oauth-proxy/README.md
@@ -21,7 +21,7 @@ Set up Dynamo DB locally
 The following dev-config value needs to be set `"dynamo_local": "localhost:8000",`
 
 ```
-docker run -p 8000:8000 amazon/dynamodb-local -jar DynamoDBLocal.jar -sharedDb -inMemory
+docker run -d -p 8000:8000 amazon/dynamodb-local -jar DynamoDBLocal.jar -sharedDb -inMemory
 node dynamo_schema.js --local=true
 ```
 

--- a/oauth-proxy/README.md
+++ b/oauth-proxy/README.md
@@ -21,7 +21,7 @@ Set up Dynamo DB locally
 The following dev-config value needs to be set `"dynamo_local": "localhost:8000",`
 
 ```
-docker run -d -p 8000:8000 amazon/dynamodb-local -jar DynamoDBLocal.jar -sharedDb -inMemory
+docker run -p 8000:8000 amazon/dynamodb-local -jar DynamoDBLocal.jar -sharedDb -inMemory
 node dynamo_schema.js --local=true
 ```
 

--- a/oauth-proxy/dynamo_schema.js
+++ b/oauth-proxy/dynamo_schema.js
@@ -96,6 +96,7 @@ tableParams = {
     { AttributeName: "state", AttributeType: "S" },
     { AttributeName: "code", AttributeType: "S" },
     { AttributeName: "refresh_token", AttributeType: "S" },
+    { AttributeName: "access_token", AttributeType: "S" },
   ],
   KeySchema: [{ AttributeName: "internal_state", KeyType: "HASH" }],
   ProvisionedThroughput: {
@@ -140,6 +141,22 @@ tableParams = {
       KeySchema: [
         {
           AttributeName: "refresh_token",
+          KeyType: "HASH",
+        },
+      ],
+      Projection: {
+        ProjectionType: "ALL",
+      },
+      ProvisionedThroughput: {
+        ReadCapacityUnits: 10,
+        WriteCapacityUnits: 10,
+      },
+    },
+    {
+      IndexName: "oauth_access_token_index",
+      KeySchema: [
+        {
+          AttributeName: "access_token",
           KeyType: "HASH",
         },
       ],

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
@@ -48,17 +48,13 @@ class SaveDocumentStateStrategy {
               this.config.hmac_secret
             ),
             iss: this.issuer,
-          };
-          if (tokens.refresh_token) {
-            payload.refresh_token = hashString(
+            refresh_token: hashString(
               tokens.refresh_token,
               this.config.hmac_secret
-            );
-            payload.expires_on =
-              Math.round(Date.now() / 1000) + 60 * 60 * 24 * 42;
-          } else {
-            payload.expires_on = tokens.expires_at;
-          }
+            ),
+            expires_on: Math.round(Date.now() / 1000) + 60 * 60 * 24 * 42,
+          };
+
           if (document.launch) {
             payload.launch = document.launch;
           }

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
@@ -3,12 +3,12 @@ const jwtDecode = require("jwt-decode");
 const { v4: uuidv4 } = require("uuid");
 
 class SaveDocumentStateStrategy {
-  constructor(req, logger, dynamoClient, config, issuer_client) {
+  constructor(req, logger, dynamoClient, config, issuer) {
     this.req = req;
     this.logger = logger;
     this.dynamoClient = dynamoClient;
     this.config = config;
-    this.issuer_client = issuer_client;
+    this.issuer = issuer;
   }
   async saveDocumentToDynamo(document, tokens) {
     try {
@@ -19,7 +19,7 @@ class SaveDocumentStateStrategy {
               tokens.access_token,
               this.config.hmac_secret
             ),
-            iss: this.issuer_client.issuer,
+            iss: this.issuer,
           };
 
           if (tokens.refresh_token) {
@@ -47,7 +47,7 @@ class SaveDocumentStateStrategy {
               tokens.access_token,
               this.config.hmac_secret
             ),
-            iss: this.issuer_client.issuer,
+            iss: this.issuer,
           };
           if (tokens.refresh_token) {
             payload.refresh_token = hashString(

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
@@ -3,11 +3,12 @@ const jwtDecode = require("jwt-decode");
 const { v4: uuidv4 } = require("uuid");
 
 class SaveDocumentStateStrategy {
-  constructor(req, logger, dynamoClient, config) {
+  constructor(req, logger, dynamoClient, config, issuer_client) {
     this.req = req;
     this.logger = logger;
     this.dynamoClient = dynamoClient;
     this.config = config;
+    this.issuer_client = issuer_client;
   }
   async saveDocumentToDynamo(document, tokens) {
     try {
@@ -20,6 +21,8 @@ class SaveDocumentStateStrategy {
                 tokens.refresh_token,
                 this.config.hmac_secret
               ),
+              access_token: tokens.access_token,
+              iss: this.issuer_client.issuer,
               // 42 days
               expires_on: Math.round(Date.now() / 1000) + 60 * 60 * 24 * 42,
             },
@@ -34,6 +37,8 @@ class SaveDocumentStateStrategy {
               tokens.refresh_token,
               this.config.hmac_secret
             ),
+            access_token: tokens.access_token,
+            iss: this.issuer_client.issuer,
             // 42 days
             expires_on: Math.round(Date.now() / 1000) + 60 * 60 * 24 * 42,
           };

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
@@ -20,8 +20,6 @@ class SaveDocumentStateStrategy {
               this.config.hmac_secret
             ),
             iss: this.issuer_client.issuer,
-            // 42 days
-            expires_on: Math.round(Date.now() / 1000) + 60 * 60 * 24 * 42,
           };
 
           if (tokens.refresh_token) {
@@ -29,6 +27,10 @@ class SaveDocumentStateStrategy {
               tokens.refresh_token,
               this.config.hmac_secret
             );
+            updated_document.expires_on =
+              Math.round(Date.now() / 1000) + 60 * 60 * 24 * 42;
+          } else {
+            updated_document.expires_on = tokens.expires_at;
           }
 
           await this.dynamoClient.updateToDynamo(

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
@@ -12,15 +12,14 @@ class SaveDocumentStateStrategy {
   }
   async saveDocumentToDynamo(document, tokens) {
     try {
-      if (document.state && tokens.refresh_token) {
+      if (document.state && tokens.access_token) {
         if (document.internal_state) {
           await this.dynamoClient.updateToDynamo(
             { internal_state: document.internal_state },
             {
-              refresh_token: hashString(
-                tokens.refresh_token,
-                this.config.hmac_secret
-              ),
+              refresh_token: tokens.refresh_token
+                ? hashString(tokens.refresh_token, this.config.hmac_secret)
+                : null,
               access_token: hashString(
                 tokens.access_token,
                 this.config.hmac_secret

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
@@ -21,7 +21,10 @@ class SaveDocumentStateStrategy {
                 tokens.refresh_token,
                 this.config.hmac_secret
               ),
-              access_token: tokens.access_token,
+              access_token: hashString(
+                tokens.access_token,
+                this.config.hmac_secret
+              ),
               iss: this.issuer_client.issuer,
               // 42 days
               expires_on: Math.round(Date.now() / 1000) + 60 * 60 * 24 * 42,
@@ -37,7 +40,10 @@ class SaveDocumentStateStrategy {
               tokens.refresh_token,
               this.config.hmac_secret
             ),
-            access_token: tokens.access_token,
+            access_token: hashString(
+              tokens.access_token,
+              this.config.hmac_secret
+            ),
             iss: this.issuer_client.issuer,
             // 42 days
             expires_on: Math.round(Date.now() / 1000) + 60 * 60 * 24 * 42,

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
@@ -43,18 +43,22 @@ class SaveDocumentStateStrategy {
             internal_state: uuidv4(),
             state: document.state,
             redirect_uri: document.redirect_uri,
-            refresh_token: hashString(
-              tokens.refresh_token,
-              this.config.hmac_secret
-            ),
             access_token: hashString(
               tokens.access_token,
               this.config.hmac_secret
             ),
             iss: this.issuer_client.issuer,
-            // 42 days
-            expires_on: Math.round(Date.now() / 1000) + 60 * 60 * 24 * 42,
           };
+          if (tokens.refresh_token) {
+            payload.refresh_token = hashString(
+              tokens.refresh_token,
+              this.config.hmac_secret
+            );
+            payload.expires_on =
+              Math.round(Date.now() / 1000) + 60 * 60 * 24 * 42;
+          } else {
+            payload.expires_on = tokens.expires_at;
+          }
           if (document.launch) {
             payload.launch = document.launch;
           }

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClientBuilder.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClientBuilder.js
@@ -99,7 +99,8 @@ const getStrategies = (
         req,
         logger,
         dynamoClient,
-        config
+        config,
+        issuer
       ),
       getPatientInfoStrategy: new GetPatientInfoFromValidateEndpointStrategy(
         validateToken,
@@ -124,7 +125,8 @@ const getStrategies = (
         req,
         logger,
         dynamoClient,
-        config
+        config,
+        issuer
       ),
       getPatientInfoStrategy: new GetPatientInfoFromValidateEndpointStrategy(
         validateToken,

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClientBuilder.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/tokenHandlerClientBuilder.js
@@ -100,7 +100,7 @@ const getStrategies = (
         logger,
         dynamoClient,
         config,
-        issuer
+        issuer.issuer
       ),
       getPatientInfoStrategy: new GetPatientInfoFromValidateEndpointStrategy(
         validateToken,
@@ -126,7 +126,7 @@ const getStrategies = (
         logger,
         dynamoClient,
         config,
-        issuer
+        issuer.issuer
       ),
       getPatientInfoStrategy: new GetPatientInfoFromValidateEndpointStrategy(
         validateToken,

--- a/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
+++ b/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
@@ -5,6 +5,7 @@ const {
   createFakeConfig,
 } = require("../testUtils");
 const MockExpressRequest = require("mock-express-request");
+const { Issuer } = require("openid-client");
 const {
   SaveDocumentStateStrategy,
 } = require("../../oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy");
@@ -75,7 +76,8 @@ describe("saveDocumentStateStrategy tests", () => {
       req,
       logger,
       dynamoClient,
-      config
+      config,
+      new Issuer({ issuer: "issuer" })
     );
     strategy.saveDocumentToDynamo(document, tokens);
     expect(logger.error).not.toHaveBeenCalled();
@@ -93,7 +95,8 @@ describe("saveDocumentStateStrategy tests", () => {
       req,
       logger,
       dynamoClient,
-      config
+      config,
+      new Issuer({ issuer: "issuer" })
     );
     strategy.saveDocumentToDynamo(document, tokens);
     expect(logger.error).not.toHaveBeenCalled();
@@ -113,7 +116,8 @@ describe("saveDocumentStateStrategy tests", () => {
       req,
       logger,
       dynamoClient,
-      config
+      config,
+      new Issuer({ issuer: "issuer" })
     );
     strategy.saveDocumentToDynamo(document, tokens);
     expect(dynamoClient.updateToDynamo).toHaveBeenCalledWith(
@@ -122,6 +126,8 @@ describe("saveDocumentStateStrategy tests", () => {
         expires_on: 3628800,
         refresh_token:
           "9b4dba523ad0a7e323452871556d691787cd90c6fe959b040c5864979db5e337",
+        access_token: tokens.access_token,
+        iss: "issuer",
       },
       "OAuthRequestsV2"
     );
@@ -146,7 +152,8 @@ describe("saveDocumentStateStrategy tests", () => {
       req,
       logger,
       dynamoClient,
-      config
+      config,
+      new Issuer({ issuer: "issuer" })
     );
     strategy.saveDocumentToDynamo(document, tokens);
     expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalledWith(
@@ -157,6 +164,8 @@ describe("saveDocumentStateStrategy tests", () => {
         refresh_token:
           "9b4dba523ad0a7e323452871556d691787cd90c6fe959b040c5864979db5e337",
         state: "abc123",
+        access_token: tokens.access_token,
+        iss: "issuer",
       },
       "OAuthRequestsV2"
     );
@@ -174,7 +183,8 @@ describe("saveDocumentStateStrategy tests", () => {
       req,
       logger,
       dynamoClient,
-      config
+      config,
+      new Issuer({ issuer: "issuer" })
     );
     strategy.saveDocumentToDynamo(document, tokens);
     expect(logger.error).not.toHaveBeenCalled();
@@ -189,7 +199,8 @@ describe("saveDocumentStateStrategy tests", () => {
       req,
       logger,
       dynamoClient,
-      config
+      config,
+      new Issuer({ issuer: "issuer" })
     );
     strategy.saveDocumentToDynamo(document, tokens);
     expect(logger.error).toHaveBeenCalled();

--- a/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
+++ b/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
@@ -267,47 +267,7 @@ describe("saveDocumentStateStrategy tests", () => {
     expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalled();
     expect(dynamoClient.updateToDynamo).not.toHaveBeenCalled();
   });
-
-  it("Happy Path w/o internal_state no Refresh Token", async () => {
-    document = {
-      state: STATE,
-      code: CODE_HASH_PAIR[0],
-      refresh_token: REFRESH_TOKEN_HASH_PAIR[0],
-      redirect_uri: REDIRECT_URI,
-    };
-    tokens.access_token =
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NwIjpbIm9wZW5pZCJdLCJpYXQiOjE1MTYyMzkwMjJ9.cLdCTxvmVuJEr5gJEG_gv0C2j1AZyIYMWplicL9LYJA";
-    dynamoClient = buildFakeDynamoClient({
-      state: STATE,
-      code: CODE_HASH_PAIR[1],
-      refresh_token: REFRESH_TOKEN_HASH_PAIR[1],
-      redirect_uri: REDIRECT_URI,
-    });
-    let strategy = new SaveDocumentStateStrategy(
-      req,
-      logger,
-      dynamoClient,
-      config,
-      "issuer"
-    );
-
-    delete tokens.refresh_token;
-    tokens.expires_at = 1234;
-    await strategy.saveDocumentToDynamo(document, tokens);
-    expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalledWith(
-      {
-        expires_on: 1234,
-        internal_state: "fake-uuid",
-        redirect_uri: "http://localhost/thisDoesNotMatter",
-        state: "abc123",
-        access_token:
-          "445e86848afba374749043f46fbee19b4d06eec99f3b876ddc32a7f8aec67dcd",
-        iss: "issuer",
-      },
-      "OAuthRequestsV2"
-    );
-    expect(dynamoClient.updateToDynamo).not.toHaveBeenCalled();
-  });
+  
   it("No Document State", async () => {
     document.state = null;
     dynamoClient = buildFakeDynamoClient({

--- a/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
+++ b/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
@@ -101,6 +101,29 @@ describe("saveDocumentStateStrategy tests", () => {
     strategy.saveDocumentToDynamo(document, tokens);
     expect(logger.error).not.toHaveBeenCalled();
   });
+
+  it("Happy Path no Refresh in Token", () => {
+    document.launch = LAUNCH;
+    dynamoClient = buildFakeDynamoClient({
+      state: STATE,
+      code: CODE_HASH_PAIR[1],
+      launch: LAUNCH,
+      redirect_uri: REDIRECT_URI,
+    });
+    let strategy = new SaveDocumentStateStrategy(
+      req,
+      logger,
+      dynamoClient,
+      config,
+      new Issuer({ issuer: "issuer" })
+    );
+
+    delete tokens.access_token;
+
+    strategy.saveDocumentToDynamo(document, tokens);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
   it("Happy Path with launch w/o scope", () => {
     document.launch = LAUNCH;
     tokens.access_token =

--- a/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
+++ b/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
@@ -126,7 +126,8 @@ describe("saveDocumentStateStrategy tests", () => {
         expires_on: 3628800,
         refresh_token:
           "9b4dba523ad0a7e323452871556d691787cd90c6fe959b040c5864979db5e337",
-        access_token: tokens.access_token,
+        access_token:
+          "445e86848afba374749043f46fbee19b4d06eec99f3b876ddc32a7f8aec67dcd",
         iss: "issuer",
       },
       "OAuthRequestsV2"
@@ -164,7 +165,8 @@ describe("saveDocumentStateStrategy tests", () => {
         refresh_token:
           "9b4dba523ad0a7e323452871556d691787cd90c6fe959b040c5864979db5e337",
         state: "abc123",
-        access_token: tokens.access_token,
+        access_token:
+          "445e86848afba374749043f46fbee19b4d06eec99f3b876ddc32a7f8aec67dcd",
         iss: "issuer",
       },
       "OAuthRequestsV2"

--- a/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
+++ b/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
@@ -263,7 +263,8 @@ describe("saveDocumentStateStrategy tests", () => {
     );
     await strategy
       .saveDocumentToDynamo(document, tokens)
-      .then(() => fail("should have thrown error")).catch(() => expect(true));
+      .then(() => fail("should have thrown error"))
+      .catch(() => expect(true));
     expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalled();
     expect(dynamoClient.updateToDynamo).not.toHaveBeenCalled();
   });

--- a/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
+++ b/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
@@ -5,7 +5,6 @@ const {
   createFakeConfig,
 } = require("../testUtils");
 const MockExpressRequest = require("mock-express-request");
-const { Issuer } = require("openid-client");
 const {
   SaveDocumentStateStrategy,
 } = require("../../oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy");
@@ -77,7 +76,7 @@ describe("saveDocumentStateStrategy tests", () => {
       logger,
       dynamoClient,
       config,
-      new Issuer({ issuer: "issuer" })
+      "issuer"
     );
     await strategy.saveDocumentToDynamo(document, tokens);
     expect(logger.error).not.toHaveBeenCalled();
@@ -96,7 +95,7 @@ describe("saveDocumentStateStrategy tests", () => {
       logger,
       dynamoClient,
       config,
-      new Issuer({ issuer: "issuer" })
+      "issuer"
     );
     await strategy.saveDocumentToDynamo(document, tokens);
     expect(logger.error).not.toHaveBeenCalled();
@@ -115,7 +114,7 @@ describe("saveDocumentStateStrategy tests", () => {
       logger,
       dynamoClient,
       config,
-      new Issuer({ issuer: "issuer" })
+      "issuer"
     );
 
     delete tokens.refresh_token;
@@ -140,7 +139,7 @@ describe("saveDocumentStateStrategy tests", () => {
       logger,
       dynamoClient,
       config,
-      new Issuer({ issuer: "issuer" })
+      "issuer"
     );
     await strategy.saveDocumentToDynamo(document, tokens);
     expect(dynamoClient.updateToDynamo).toHaveBeenCalledWith(
@@ -177,7 +176,7 @@ describe("saveDocumentStateStrategy tests", () => {
       logger,
       dynamoClient,
       config,
-      new Issuer({ issuer: "issuer" })
+      "issuer"
     );
     await strategy.saveDocumentToDynamo(document, tokens);
     expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalledWith(
@@ -217,7 +216,7 @@ describe("saveDocumentStateStrategy tests", () => {
       logger,
       dynamoClient,
       config,
-      new Issuer({ issuer: "issuer" })
+      "issuer"
     );
     await strategy.saveDocumentToDynamo(document, tokens);
     expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalledWith(
@@ -259,7 +258,7 @@ describe("saveDocumentStateStrategy tests", () => {
       logger,
       dynamoClient,
       config,
-      new Issuer({ issuer: "issuer" })
+      "issuer"
     );
     await strategy
       .saveDocumentToDynamo(document, tokens)
@@ -289,7 +288,7 @@ describe("saveDocumentStateStrategy tests", () => {
       logger,
       dynamoClient,
       config,
-      new Issuer({ issuer: "issuer" })
+      "issuer"
     );
 
     delete tokens.refresh_token;
@@ -322,7 +321,7 @@ describe("saveDocumentStateStrategy tests", () => {
       logger,
       dynamoClient,
       config,
-      new Issuer({ issuer: "issuer" })
+      "issuer"
     );
     await strategy.saveDocumentToDynamo(document, tokens);
     expect(logger.error).not.toHaveBeenCalled();
@@ -338,7 +337,7 @@ describe("saveDocumentStateStrategy tests", () => {
       logger,
       dynamoClient,
       config,
-      new Issuer({ issuer: "issuer" })
+      "issuer"
     );
     await strategy.saveDocumentToDynamo(document, tokens);
     expect(logger.error).toHaveBeenCalled();

--- a/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
+++ b/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
@@ -267,7 +267,7 @@ describe("saveDocumentStateStrategy tests", () => {
     expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalled();
     expect(dynamoClient.updateToDynamo).not.toHaveBeenCalled();
   });
-  
+
   it("No Document State", async () => {
     document.state = null;
     dynamoClient = buildFakeDynamoClient({


### PR DESCRIPTION
# Description

Add Access Token and ISS to OAuthRequestsV2 on Token requests.

# TODO

- [x] Create PR to Add `oauth_access_token_index` to `OAuthRequestsV2`
    https://github.com/department-of-veterans-affairs/lighthouse-devops-support/issues/280
    - [x] Add `oauth_access_token_index` to `OAuthRequestsV2` in `dynamo_schema.js`
    **note** this index is not required to store the access_token, but will be important for [API-5575](https://vajira.max.gov/browse/API-5575)
- [x] Add logic to store access_token in the tokenHandlerClient.
- [x] In SaveDocumentByState create a common payload instantiation to reduce repeated code.
- [x] Unit Tests
- [x] Manual Tests

# Tests

## Happy Path Okta no offline_access

**Test Steps**

- Go through Oauth flow on default issuer with no offline access scope. Proves that token flow saves document with no refresh_token,

**Expected Results**

```sh
aws dynamodb scan --table-name OAuthRequestsV2 --endpoint-url http://localhost:8000
```

should return following fields

- [x] code
- [x] internal_state
- [x] redirect_uri
- [x] state
- [x] expires_on
- [x] access_token
- [x] iss


### Happy Path

**Test Steps**

- Go through Oauth flow on default issuer.

**Expected Results**

```sh
aws dynamodb scan --table-name OAuthRequestsV2 --endpoint-url http://localhost:8000
```

should return following fields

- [x] code
- [x] internal_state
- [x] redirect_uri
- [x] state
- [x] expires_on
- [x] access_token
- [x] refresh_token
- [x] iss

## Refresh

**Test Steps**

- Go through refresh flow on default issuer.

**Expected Results**

```sh
aws dynamodb scan --table-name OAuthRequestsV2 --endpoint-url http://localhost:8000
```

should return following fields

- [x] code
- [x] internal_state
- [x] redirect_uri
- [x] state
- [x] expires_on
- [x] access_token
- [x] refresh_token
- [x] iss

## Refresh Pull Document from OAuthRequestsV1

**Test Steps**

- Go through Token Flow
- Delete Token Item in OAuthRequestsV2
- Inject Code, State and Refresh_Token into OAuthRequests
- Go through refresh token flow.

**Expected Results**

```sh
aws dynamodb scan --table-name OAuthRequestsV2 --endpoint-url http://localhost:8080
```

should return following fields

- [x] code
- [x] internal_state
- [x] redirect_uri
- [x] state
- [x] expires_on
- [x] access_token
- [x] refresh_token
- [x] iss

~~Refresh Pull Document from OAuthRequestsV1 no Access Token~~

Does not make sense...