### PR TITLE
Eliminate calling release job from CI

### DIFF
--- a/saml-proxy/cicd/buildspec-ci.yml
+++ b/saml-proxy/cicd/buildspec-ci.yml
@@ -38,19 +38,6 @@ phases:
       - time="Start - $(date +%r)"
       # Generate short ref
       - COMMIT_HASH=${CODEBUILD_RESOLVED_SOURCE_VERSION:0:7}
-      # Get usable branch name
-      - GET_BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#"refs/heads/"}
-      # set branch if not set from webhook
-      - |
-        if [[ $BRANCH ]]; then
-          echo branch set as -- ${BRANCH} -- from console
-        elif [[ ${GET_BRANCH} ]]; then
-          echo branch set as -- ${GET_BRANCH} -- from webhook
-          BRANCH=${GET_BRANCH}
-        else
-          echo No branch found... setting to \"default\"
-          BRANCH=default
-        fi
       # printenv variables to Cloud Watch incase of failure
       - printenv
   build:
@@ -77,8 +64,3 @@ phases:
       - echo Pushing image to ECR
       - time="${time}\nPush - $(date +%r) - started"
       - make push IMAGE=${IMAGE} TAG=${COMMIT_HASH}
-      - time="${time}\nRelease - $(date +%r) - started"
-      - |
-        if [[ ${BRANCH} == 'master' ]]; then
-          aws codebuild start-build --project-name saml-proxy-release --source-version ${CODEBUILD_RESOLVED_SOURCE_VERSION}
-        fi

--- a/saml-proxy/cicd/buildspec-release.yml
+++ b/saml-proxy/cicd/buildspec-release.yml
@@ -15,14 +15,17 @@
 # Custom Scripts:
 #  - slackpost.sh
 #  - increment.sh
+#  - gh-status.sh
 #######################################################################
 version: 0.2
 env:
   shell: bash
   variables:
     DEPLOY: "true"
-    REPO: "/repos/department-of-veterans-affairs/vets-saml-proxy"
+    REPO: "vets-saml-proxy"
     IMAGE: "saml-proxy"
+    # Checks that are not included for the ghstatus script.
+    XCHECKS: "saml-proxy-release"
   parameter-store:
     GITHUB_TOKEN: "/dvp/devops/va_bot_github_token"
     # SLACK_WEBHOOK should be a webhook that posts to the Slack channel you want notifications to go to
@@ -40,21 +43,7 @@ phases:
     commands:
       - slackpost.sh -t started "started SAML Proxy release..."
       # check ci status of current commit hash
-      - ci_status=$(gh api ${REPO}/commits/${COMMIT_HASH}/status | jq -r .state)
-      - |
-        echo "commit status: ${ci_status}"
-      - |
-        while [[ ${ci_status} == "pending" ]]; do
-          echo "ci still running -- sleep"
-          ci_status=$(gh api ${REPO}/commits/${COMMIT_HASH}/status | jq -r .state)
-          echo "commit status: ${ci_status}"
-          sleep 10
-        done
-      - |
-        if [[ ${ci_status} != "success" ]]; then
-          echo "ci failed release aborted. ci status was ${ci_status}"
-          exit 1
-        fi
+      - gh-status.sh -r ${REPO} -c ${COMMIT_HASH} -x ${XCHECKS}
       # create new tag
       - old_tag=$(git tag --sort=-creatordate | grep fargate-saml-proxy | head -1)
       - echo "found ${old_tag} - incrementing..."


### PR DESCRIPTION
This PR will eliminate the need for CI to call release job. The logic will be replaced by a webhook for push to `master` reference coordinated Terraform PR here https://github.com/department-of-veterans-affairs/devops/pull/8705