### PR TITLE
grab exp from token object

### DIFF
--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentLaunchStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentLaunchStrategy.js
@@ -1,4 +1,3 @@
-const jwtDecode = require("jwt-decode");
 const { hashString } = require("../../../utils");
 
 class SaveDocumentLaunchStrategy {
@@ -16,11 +15,10 @@ class SaveDocumentLaunchStrategy {
           this.config.hmac_secret
         );
 
-        let decodedToken = jwtDecode(tokens.access_token);
         let payload = {
           access_token: accessToken,
           launch: launch,
-          expires_on: decodedToken.exp,
+          expires_on: Math.round(Date.now() / 1000) + tokens.expires_in,
         };
 
         await this.dynamoClient.savePayloadToDynamo(

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
@@ -1,5 +1,4 @@
 const { hashString } = require("../../../utils");
-const jwtDecode = require("jwt-decode");
 const { v4: uuidv4 } = require("uuid");
 
 class SaveDocumentStateStrategy {
@@ -75,7 +74,6 @@ class SaveDocumentStateStrategy {
 
     try {
       if (document.launch && tokens.access_token) {
-        let decodedToken = jwtDecode(tokens.access_token);
         if (tokens.scope && tokens.scope.split(" ").includes("launch")) {
           let launch = document.launch;
           let accessToken = hashString(
@@ -86,7 +84,7 @@ class SaveDocumentStateStrategy {
           let payload = {
             access_token: accessToken,
             launch: launch,
-            expires_on: decodedToken.exp,
+            expires_on: Math.round(Date.now() / 1000) + tokens.expires_in,
           };
 
           await this.dynamoClient.savePayloadToDynamo(

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
@@ -1,5 +1,4 @@
 const { hashString } = require("../../../utils");
-const jwtDecode = require("jwt-decode");
 const { v4: uuidv4 } = require("uuid");
 
 class SaveDocumentStateStrategy {

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
@@ -75,7 +75,6 @@ class SaveDocumentStateStrategy {
 
     try {
       if (document.launch && tokens.access_token) {
-        let decodedToken = jwtDecode(tokens.access_token);
         if (tokens.scope && tokens.scope.split(" ").includes("launch")) {
           let launch = document.launch;
           let accessToken = hashString(
@@ -86,7 +85,7 @@ class SaveDocumentStateStrategy {
           let payload = {
             access_token: accessToken,
             launch: launch,
-            expires_on: decodedToken.exp,
+            expires_on: tokens.expires_at,
           };
 
           await this.dynamoClient.savePayloadToDynamo(

--- a/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
+++ b/oauth-proxy/oauthHandlers/tokenHandlerStrategyClasses/saveDocumentStrategies/saveDocumentStateStrategy.js
@@ -1,4 +1,5 @@
 const { hashString } = require("../../../utils");
+const jwtDecode = require("jwt-decode");
 const { v4: uuidv4 } = require("uuid");
 
 class SaveDocumentStateStrategy {
@@ -74,6 +75,7 @@ class SaveDocumentStateStrategy {
 
     try {
       if (document.launch && tokens.access_token) {
+        let decodedToken = jwtDecode(tokens.access_token);
         if (tokens.scope && tokens.scope.split(" ").includes("launch")) {
           let launch = document.launch;
           let accessToken = hashString(
@@ -84,7 +86,7 @@ class SaveDocumentStateStrategy {
           let payload = {
             access_token: accessToken,
             launch: launch,
-            expires_on: tokens.expires_at,
+            expires_on: decodedToken.exp,
           };
 
           await this.dynamoClient.savePayloadToDynamo(

--- a/oauth-proxy/tests/TokenHandlerTests/saveDocumentLaunchStrategy.test.js
+++ b/oauth-proxy/tests/TokenHandlerTests/saveDocumentLaunchStrategy.test.js
@@ -13,10 +13,21 @@ const {
 require("jest");
 
 describe("saveDocumentToDynamo tests", () => {
-  let logger = buildFakeLogger();
+  let logger;
   let dynamoClient;
-  let config = createFakeConfig();
-  let hashingFunction = createFakeHashingFunction();
+  let config;
+  let hashingFunction;
+
+  beforeEach(() => {
+    logger = buildFakeLogger();
+    config = createFakeConfig();
+    hashingFunction = createFakeHashingFunction();
+    jest.spyOn(global.Math, "round").mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    jest.spyOn(global.Math, "round").mockRestore();
+  });
 
   it("Empty Tokens", async () => {
     let token = buildToken(false, false);
@@ -80,7 +91,7 @@ describe("saveDocumentToDynamo tests", () => {
       {
         access_token:
           "e0f866111645e58199f0382a6fa50a217b0c2ccc1ca07e27738e758e1183a8db",
-        expires_on: 1516239023,
+        expires_on: 300,
         launch: {
           S: "launch",
         },

--- a/oauth-proxy/tests/TokenHandlerTests/saveDocumentLaunchStrategy.test.js
+++ b/oauth-proxy/tests/TokenHandlerTests/saveDocumentLaunchStrategy.test.js
@@ -53,12 +53,9 @@ describe("saveDocumentToDynamo tests", () => {
       config,
       hashingFunction
     );
-    const expire_on = new Date().getTime() + 300 * 1000;
-    let encoded_token = jwtEncodeClaims(token, expire_on);
-    await strategy.saveDocumentToDynamo(document, {
-      access_token: encoded_token,
-    });
 
+    await strategy.saveDocumentToDynamo(document, token);
+    expect(dynamoClient.savePayloadToDynamo).not.toHaveBeenCalled();
     expect(logger.error.mock.calls).toHaveLength(0);
   });
 
@@ -78,12 +75,19 @@ describe("saveDocumentToDynamo tests", () => {
       config,
       hashingFunction
     );
-    const expire_on = new Date().getTime() + 300 * 1000;
-    let encoded_token = jwtEncodeClaims(token, expire_on);
-    await strategy.saveDocumentToDynamo(document, {
-      access_token: encoded_token,
-    });
 
+    await strategy.saveDocumentToDynamo(document, token);
+    expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalledWith(
+      {
+        access_token:
+          "8ce1212e7c1ce218f9fc5daf75d918eaa18feb06507d096f5bb9d6846b02e98c",
+        expires_on: 5678,
+        launch: {
+          S: "launch",
+        },
+      },
+      "LaunchContext"
+    );
     expect(logger.error.mock.calls).toHaveLength(0);
   });
 });

--- a/oauth-proxy/tests/TokenHandlerTests/saveDocumentLaunchStrategy.test.js
+++ b/oauth-proxy/tests/TokenHandlerTests/saveDocumentLaunchStrategy.test.js
@@ -7,7 +7,6 @@ const {
   buildFakeLogger,
   createFakeConfig,
   createFakeHashingFunction,
-  jwtEncodeClaims,
   convertObjectToDynamoAttributeValues,
 } = require("../testUtils");
 
@@ -80,8 +79,8 @@ describe("saveDocumentToDynamo tests", () => {
     expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalledWith(
       {
         access_token:
-          "8ce1212e7c1ce218f9fc5daf75d918eaa18feb06507d096f5bb9d6846b02e98c",
-        expires_on: 5678,
+          "e0f866111645e58199f0382a6fa50a217b0c2ccc1ca07e27738e758e1183a8db",
+        expires_on: 1516239023,
         launch: {
           S: "launch",
         },

--- a/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
+++ b/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
@@ -97,7 +97,7 @@ describe("saveDocumentStateStrategy tests", () => {
     expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalledWith(
       {
         access_token:
-          "9e518839129a53e22a82dbe99f3ee1b3981700108823c587370b59e9b913ef3c",
+          "4116ff9d9b7bb73aff7680b14eb012670eb93cfc7266f142f13bd1486ae6cbb1",
         expires_on: 5678,
         launch: "1234V5678",
       },
@@ -128,7 +128,7 @@ describe("saveDocumentStateStrategy tests", () => {
     expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalledWith(
       {
         access_token:
-          "9e518839129a53e22a82dbe99f3ee1b3981700108823c587370b59e9b913ef3c",
+          "4116ff9d9b7bb73aff7680b14eb012670eb93cfc7266f142f13bd1486ae6cbb1",
         expires_on: 5678,
         launch: "1234V5678",
       },
@@ -162,7 +162,7 @@ describe("saveDocumentStateStrategy tests", () => {
         refresh_token:
           "9b4dba523ad0a7e323452871556d691787cd90c6fe959b040c5864979db5e337",
         access_token:
-          "9e518839129a53e22a82dbe99f3ee1b3981700108823c587370b59e9b913ef3c",
+          "4116ff9d9b7bb73aff7680b14eb012670eb93cfc7266f142f13bd1486ae6cbb1",
         iss: "issuer",
       },
       "OAuthRequestsV2"
@@ -200,7 +200,7 @@ describe("saveDocumentStateStrategy tests", () => {
           "9b4dba523ad0a7e323452871556d691787cd90c6fe959b040c5864979db5e337",
         state: "abc123",
         access_token:
-          "9e518839129a53e22a82dbe99f3ee1b3981700108823c587370b59e9b913ef3c",
+          "4116ff9d9b7bb73aff7680b14eb012670eb93cfc7266f142f13bd1486ae6cbb1",
         iss: "issuer",
       },
       "OAuthRequestsV2"

--- a/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
+++ b/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
@@ -98,7 +98,7 @@ describe("saveDocumentStateStrategy tests", () => {
       {
         access_token:
           "4116ff9d9b7bb73aff7680b14eb012670eb93cfc7266f142f13bd1486ae6cbb1",
-        expires_on: 5678,
+        expires_on: 1516239023,
         launch: "1234V5678",
       },
       "LaunchContext"
@@ -129,7 +129,7 @@ describe("saveDocumentStateStrategy tests", () => {
       {
         access_token:
           "4116ff9d9b7bb73aff7680b14eb012670eb93cfc7266f142f13bd1486ae6cbb1",
-        expires_on: 5678,
+        expires_on: 1516239023,
         launch: "1234V5678",
       },
       "LaunchContext"

--- a/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
+++ b/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
@@ -98,7 +98,7 @@ describe("saveDocumentStateStrategy tests", () => {
       {
         access_token:
           "4116ff9d9b7bb73aff7680b14eb012670eb93cfc7266f142f13bd1486ae6cbb1",
-        expires_on: 1516239023,
+        expires_on: 300,
         launch: "1234V5678",
       },
       "LaunchContext"
@@ -129,7 +129,7 @@ describe("saveDocumentStateStrategy tests", () => {
       {
         access_token:
           "4116ff9d9b7bb73aff7680b14eb012670eb93cfc7266f142f13bd1486ae6cbb1",
-        expires_on: 1516239023,
+        expires_on: 300,
         launch: "1234V5678",
       },
       "LaunchContext"
@@ -207,7 +207,7 @@ describe("saveDocumentStateStrategy tests", () => {
     );
     expect(dynamoClient.updateToDynamo).not.toHaveBeenCalled();
   });
-  it("Happy Path w/o internal_state with launchy", async () => {
+  it("Happy Path w/o internal_state with launch", async () => {
     document = {
       state: STATE,
       code: CODE_HASH_PAIR[0],
@@ -246,6 +246,15 @@ describe("saveDocumentStateStrategy tests", () => {
       },
       "OAuthRequestsV2"
     );
+    expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalledWith(
+      {
+        access_token:
+          "445e86848afba374749043f46fbee19b4d06eec99f3b876ddc32a7f8aec67dcd",
+        expires_on: 300,
+        launch: "1234V5678",
+      },
+      "LaunchContext"
+    );
     expect(dynamoClient.updateToDynamo).not.toHaveBeenCalled();
   });
 
@@ -276,7 +285,16 @@ describe("saveDocumentStateStrategy tests", () => {
       .saveDocumentToDynamo(document, tokens)
       .then(() => fail("should have thrown error"))
       .catch(() => expect(true));
-    expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalled();
+    // expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalled();
+    expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalledWith(
+      {
+        access_token:
+          "4116ff9d9b7bb73aff7680b14eb012670eb93cfc7266f142f13bd1486ae6cbb1",
+        expires_on: 300,
+        launch: "1234V5678",
+      },
+      "LaunchContext"
+    );
     expect(dynamoClient.updateToDynamo).not.toHaveBeenCalled();
   });
 

--- a/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
+++ b/oauth-proxy/tests/TokenHandlerTests/saveDocumentStateStrategy.test.js
@@ -94,6 +94,15 @@ describe("saveDocumentStateStrategy tests", () => {
       "issuer"
     );
     await strategy.saveDocumentToDynamo(document, tokens);
+    expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalledWith(
+      {
+        access_token:
+          "9e518839129a53e22a82dbe99f3ee1b3981700108823c587370b59e9b913ef3c",
+        expires_on: 5678,
+        launch: "1234V5678",
+      },
+      "LaunchContext"
+    );
     expect(logger.error).not.toHaveBeenCalled();
   });
 
@@ -116,6 +125,15 @@ describe("saveDocumentStateStrategy tests", () => {
     delete tokens.refresh_token;
 
     await strategy.saveDocumentToDynamo(document, tokens);
+    expect(dynamoClient.savePayloadToDynamo).toHaveBeenCalledWith(
+      {
+        access_token:
+          "9e518839129a53e22a82dbe99f3ee1b3981700108823c587370b59e9b913ef3c",
+        expires_on: 5678,
+        launch: "1234V5678",
+      },
+      "LaunchContext"
+    );
     expect(logger.error).not.toHaveBeenCalled();
   });
 

--- a/oauth-proxy/tests/TokenHandlerTests/tokenHandlerTestUtils.js
+++ b/oauth-proxy/tests/TokenHandlerTests/tokenHandlerTestUtils.js
@@ -67,6 +67,7 @@ const buildToken = (
       : access_token,
     refresh_token: "the_fake_refresh_token",
     scope: scp,
+    expires_in: 5678,
   };
 
   return token;

--- a/oauth-proxy/tests/TokenHandlerTests/tokenHandlerTestUtils.js
+++ b/oauth-proxy/tests/TokenHandlerTests/tokenHandlerTestUtils.js
@@ -68,6 +68,7 @@ const buildToken = (
     refresh_token: "the_fake_refresh_token",
     scope: scp,
     expires_at: 5678,
+    expires_in: 300,
   };
 
   return token;

--- a/oauth-proxy/tests/TokenHandlerTests/tokenHandlerTestUtils.js
+++ b/oauth-proxy/tests/TokenHandlerTests/tokenHandlerTestUtils.js
@@ -1,7 +1,7 @@
 const access_token =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NwIjpbImVtYWlsLnJlYWQiXSwiaWF0IjoxNTE2MjM5MDIyfQ.lybRIPdhq6UslRqKRtiEuyqnCUY6OoDFeXRaogoPROk";
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NwIjpbImVtYWlsLnJlYWQiXSwiZXhwIjoxNTE2MjM5MDIzLCJpYXQiOjE1MTYyMzkwMjJ9.SM1PDbyfkFrCk9MPIpcQ7bTVh0fW6u0xLgL4_z_2HQo";
 const access_token_patient =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NwIjpbImxhdW5jaC9wYXRpZW50Il0sImlhdCI6MTUxNjIzOTAyMn0.2PU4pZHbSRhOgpmG9jfCgY0YEoq5hmq9LH_56e6VfzA";
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NwIjpbImxhdW5jaC9wYXRpZW50Il0sImV4cCI6MTUxNjIzOTAyMywiaWF0IjoxNTE2MjM5MDIyfQ.QNd9R70JPNEhXHxHRVRZFuxL-K8437fO-grm_8L1-GA";
 const access_token_launch =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwic2NwIjpbImxhdW5jaCJdLCJpYXQiOjE1MTYyMzkwMjJ9.61N3OfyoslutHtsG1PxVWztr77PyMiVz9Js4CwzPiV8";
 const buildGetTokenStrategy = (response, error = false) => {
@@ -67,7 +67,7 @@ const buildToken = (
       : access_token,
     refresh_token: "the_fake_refresh_token",
     scope: scp,
-    expires_in: 5678,
+    expires_at: 5678,
   };
 
   return token;


### PR DESCRIPTION
# Description

To support SSOi, the token expiration stored for code and refresh flows should be grabbed from the token object.

# Questions

~~There is a launch flow for both saveDocumentLaunchStrategy and saveDocumentStateStrategy. The client_credentials access token does not have an `expires_at` or `expires_on` field. There are also cases where this is true for regular token objects reaching the saveDocumentStateStrategy launch block; however, token objects almost always has the expires_in field, which is a long that tell the duration of time when a token will expire. For example a token may expire in 1 hour.~~ 

~~A couple things to consider:~~

- ~~If we intend to save SSOi tokens in the LaunchContext table it may be best to set the expires_at field as `now + expires_in`.~~
- ~~If we do not intend to save SSOi okens in the LaunchContext table it may be best to continue the use of the access_token's exp field because ideally this field should represent the access_tokens expiration and not the refresh token's.~~

# TODO

- [x] saveDocumentStateStrategy should store the expiration as `now + expires_on`.
- [x] saveDocumentLaunchStrategy should store the expiration as `now + expires_on`.

# Tests

## Happy Path Okta no offline_access

**Test Steps**

- Go through Oauth flow on default issuer with no offline access scope. Proves that token flow saves document with no refresh_token,

**Expected Results**

```sh
aws dynamodb scan --table-name OAuthRequestsV2 --endpoint-url http://localhost:8000
```

should return following fields

- [x] code
- [x] internal_state
- [x] redirect_uri
- [x] state
- [x] expires_on | should match the token object
- [x] access_token
- [x] iss


### Happy Path ~~With Launch~~

**Test Steps**

- Go through Oauth flow on default issuer.

**Expected Results**

```sh
aws dynamodb scan --table-name OAuthRequestsV2 --endpoint-url http://localhost:8000
```

should return following fields

- [x] code
- [x] internal_state
- [x] redirect_uri
- [x] state
- [x] expires_on | 42 days
- [x] access_token
- [x] refresh_token
- [x] iss

It does not appear that there is an issuer configured to work with the launch scope at the moment.

### SSOe

**Test Steps**

- Go through the SSOe Flow

**Expected Results**

```sh
aws dynamodb scan --table-name LaunchContext --endpoint-url http://localhost:8000
```
- [x] expires_on should be `now + expires_on` being reasonable close to what ever the current time in addition to the expires_on field should be a good indication.

## Refresh

**Test Steps**

- Go through refresh flow on default issuer.

**Expected Results**

```sh
aws dynamodb scan --table-name OAuthRequestsV2 --endpoint-url http://localhost:8000
```

should return following fields

- [x] code
- [x] internal_state
- [x] redirect_uri
- [x] state
- [x] expires_on | 42 days
- [x] access_token
- [x] refresh_token
- [x] iss

## Refresh Pull Document from OAuthRequestsV1

**Test Steps**

- Go through Token Flow
- Delete Token Item in OAuthRequestsV2
- Inject Code, State and Refresh_Token into OAuthRequests
- Go through refresh token flow.

**Expected Results**

```sh
aws dynamodb scan --table-name OAuthRequestsV2 --endpoint-url http://localhost:8080
```

should return following fields

- ? does not store code. should it?
- [x] internal_state
- [x] redirect_uri
- [x] state
- [x] expires_on | 42 days
- [x] access_token
- [x] refresh_token
- [x] iss

