### PR TITLE
isolate release job for oauth

### DIFF
--- a/oauth-proxy/cicd/buildspec-ci.yml
+++ b/oauth-proxy/cicd/buildspec-ci.yml
@@ -39,19 +39,6 @@ phases:
       - time="Start - $(date +%r)"
       # Generate short ref
       - COMMIT_HASH=${CODEBUILD_RESOLVED_SOURCE_VERSION:0:7}
-      # Get usable branch name
-      - GET_BRANCH=${CODEBUILD_WEBHOOK_HEAD_REF#"refs/heads/"}
-      # set branch if not set from webhook
-      - |
-        if [[ $BRANCH ]]; then
-          echo branch set as -- ${BRANCH} -- from console
-        elif [[ ${GET_BRANCH} ]]; then
-          echo branch set as -- ${GET_BRANCH} -- from webhook
-          BRANCH=${GET_BRANCH}
-        else
-          echo No branch found... setting to \"default\"
-          BRANCH=default
-        fi
       # printenv variables to Cloud Watch incase of failure
       - printenv
   build:
@@ -80,8 +67,3 @@ phases:
       - echo Pushing image to ECR
       - time="${time}\nPush - $(date +%r) - started"
       - make push IMAGE=${IMAGE} TAG=${COMMIT_HASH}
-      - time="${time}\nRelease - $(date +%r) - started"
-      - |
-        if [[ ${BRANCH} == 'master' ]]; then
-          aws codebuild start-build --project-name oauth-proxy-release --source-version ${CODEBUILD_RESOLVED_SOURCE_VERSION}
-        fi

--- a/oauth-proxy/cicd/buildspec-release.yml
+++ b/oauth-proxy/cicd/buildspec-release.yml
@@ -15,14 +15,17 @@
 # Custom Scripts:
 #  - slackpost.sh
 #  - increment.sh
+#  - gh-status.sh
 #######################################################################
 version: 0.2
 env:
   shell: bash
   variables:
     DEPLOY: "true"
-    REPO: "/repos/department-of-veterans-affairs/vets-saml-proxy"
+    REPO: "vets-saml-proxy"
     IMAGE: "oauth-proxy"
+    # Checks that are not included for the ghstatus script.
+    XCHECKS: "oauth-proxy-release,saml-proxy,jenkins"
   parameter-store:
     GITHUB_TOKEN: "/dvp/devops/va_bot_github_token"
     # SLACK_WEBHOOK should be a webhook that posts to the Slack channel you want notifications to go to
@@ -40,22 +43,8 @@ phases:
     commands:
       - slackpost.sh -t started "started OAuth Proxy release..."
       # check ci status of current commit hash
-      - ci_status=$(gh api ${REPO}/commits/${COMMIT_HASH}/status | jq -r .state)
-      - |
-        echo "commit status: ${ci_status}"
-      - |
-        while [[ ${ci_status} == "pending" ]]; do
-          echo "ci still running -- sleep"
-          ci_status=$(gh api ${REPO}/commits/${COMMIT_HASH}/status | jq -r .state)
-          echo "commit status: ${ci_status}"
-          sleep 10
-        done
-      - |
-        if [[ ${ci_status} != "success" ]]; then
-          echo "ci failed release aborted. ci status was ${ci_status}"
-          exit 1
-        fi
-      # create new tag
+      - gh-status.sh -r ${REPO} -c ${COMMIT_HASH} -x ${XCHECKS}
+      # find old tag
       - old_tag=$(git tag --sort=-creatordate | grep fargate-oauth-proxy | head -1)
       - echo "found ${old_tag} - incrementing..."
       # create new tag

--- a/saml-proxy/cicd/buildspec-release.yml
+++ b/saml-proxy/cicd/buildspec-release.yml
@@ -25,7 +25,7 @@ env:
     REPO: "vets-saml-proxy"
     IMAGE: "saml-proxy"
     # Checks that are not included for the ghstatus script.
-    XCHECKS: "saml-proxy-release"
+    XCHECKS: "saml-proxy-release,oauth-proxy,jenkins"
   parameter-store:
     GITHUB_TOKEN: "/dvp/devops/va_bot_github_token"
     # SLACK_WEBHOOK should be a webhook that posts to the Slack channel you want notifications to go to
@@ -44,7 +44,7 @@ phases:
       - slackpost.sh -t started "started SAML Proxy release..."
       # check ci status of current commit hash
       - gh-status.sh -r ${REPO} -c ${COMMIT_HASH} -x ${XCHECKS}
-      # create new tag
+      # create old tag
       - old_tag=$(git tag --sort=-creatordate | grep fargate-saml-proxy | head -1)
       - echo "found ${old_tag} - incrementing..."
       # create new tag


### PR DESCRIPTION
This isolates CI for OAuth. Also added to this PR are two more excluded checks for SAML.

Excluding the Jenkins check speeds up the ECS pipeline. The release job will depend solely on the CodeBuild CI job. 

Excluding the SAML check for OAuth and vice versa will ensure release isolation in a case where both products are changed and merged at the same time. 

Web hook PR: 
https://github.com/department-of-veterans-affairs/devops/pull/8747