### PR TITLE
add sleep to release jobs

### DIFF
--- a/oauth-proxy/cicd/buildspec-release.yml
+++ b/oauth-proxy/cicd/buildspec-release.yml
@@ -41,6 +41,8 @@ phases:
       - printenv
   build:
     commands:
+      # provide delay for CI jobs to kickoff.
+      - sleep 90s
       - slackpost.sh -t started "started OAuth Proxy release..."
       # check ci status of current commit hash
       - gh-status.sh -r ${REPO} -c ${COMMIT_HASH} -x ${XCHECKS}

--- a/saml-proxy/cicd/buildspec-release.yml
+++ b/saml-proxy/cicd/buildspec-release.yml
@@ -41,6 +41,8 @@ phases:
       - printenv
   build:
     commands:
+      # provide delay for CI jobs to kickoff.
+      - sleep 90s
       - slackpost.sh -t started "started SAML Proxy release..."
       # check ci status of current commit hash
       - gh-status.sh -r ${REPO} -c ${COMMIT_HASH} -x ${XCHECKS}


### PR DESCRIPTION
Recent release job failure occurred due too CI webhook not hitting Github prior to gh-status check script kicking off. This is a short term solution while I add a mandatory switch to the `gh-status` tool that will ensure check completes prior to continuing release job. 