### PR TITLE
API-6036 - Default IDP per Authz Route

### DIFF
--- a/oauth-proxy/cli.js
+++ b/oauth-proxy/cli.js
@@ -203,6 +203,11 @@ function processArgs() {
               default: null,
             },
           },
+          idp: {
+            description:
+              "Default Okta IDP for this authz server (overrides global default)",
+            required: false,
+          },
         },
         app_routes: {
           description:

--- a/oauth-proxy/oauthHandlers/authorizeHandler.js
+++ b/oauth-proxy/oauthHandlers/authorizeHandler.js
@@ -109,10 +109,11 @@ const authorizeHandler = async (
   params.set("redirect_uri", redirect_uri);
   // Rewrite to an internally maintained state
   params.set("state", internal_state);
-  if (params.has("idp")) {
-    params.set("idp", slugHelper.rewrite(params.get("idp")));
-  } else if (!params.has("idp") && idp) {
-    params.set("idp", idp);
+
+  // Set the optional IDP (using a preferred order)
+  const oktaIdp = slugHelper.rewrite(params.get("idp"), app_category.idp, idp);
+  if (oktaIdp) {
+    params.set("idp", oktaIdp);
   }
 
   res.redirect(

--- a/oauth-proxy/slug_helper.js
+++ b/oauth-proxy/slug_helper.js
@@ -11,18 +11,27 @@ class SlugHelper {
   }
 
   /**
-   * Rewrites the slug to a target url based on configuration settings.
+   * Rewrites a slug to a value based on configuration settings.
    *
-   * @param {*} slug The slug to rewrite.
+   * If more than one slug is provided, the first non-empty value will be rewritten.
+   *
+   * @param {string} slugs The slugs (in preferred order) to rewrite.
+   * @returns {string|null} a rewritten value or null.
    */
-  rewrite(slug) {
-    if (!this.idps) {
-      return slug;
+  rewrite(...slugs) {
+    for (const slug of slugs) {
+      if (slug) {
+        if (!this.idps) {
+          return slug;
+        }
+        const matchedSlug = this.idps.find((item) => {
+          return item.slug === slug;
+        });
+        return matchedSlug ? matchedSlug.id : slug;
+      }
     }
-    const matchedSlug = this.idps.find((item) => {
-      return item.slug === slug;
-    });
-    return matchedSlug ? matchedSlug.id : slug;
+
+    return null;
   }
 }
 

--- a/oauth-proxy/tests/authorizeHandler.test.js
+++ b/oauth-proxy/tests/authorizeHandler.test.js
@@ -17,8 +17,14 @@ const getAuthorizationServerInfoMock = jest.fn();
 const mockSlugHelper = {
   rewrite: jest.fn(),
 };
-mockSlugHelper.rewrite.mockImplementation((slug) => {
-  return slug;
+mockSlugHelper.rewrite.mockImplementation((...slugs) => {
+  for (const slug of slugs) {
+    if (slug) {
+      return slug;
+    }
+  }
+
+  return null;
 });
 const userCollection = new Collection("", "", new ModelFactory(User));
 userCollection.currentItems = [{ id: 1 }];
@@ -154,6 +160,12 @@ describe("Happy Path", () => {
   });
 
   it("Happy Path Redirect using config idp", async () => {
+    mockSlugHelper.rewrite.mockImplementation(
+      (slugFromParam, slugFromAuthzRoute, slugFromConfig) => {
+        return slugFromConfig;
+      }
+    );
+
     let response = buildFakeGetAuthorizationServerInfoResponse(["aud"]);
     getAuthorizationServerInfoMock.mockResolvedValue(response);
 

--- a/oauth-proxy/tests/slug_helper.test.js
+++ b/oauth-proxy/tests/slug_helper.test.js
@@ -32,20 +32,20 @@ describe("slug helper tests", () => {
     expect(slugHelper.rewrite("xxx")).toBe("xxx");
   });
 
-  it("rewrite preference 1", async() => {
+  it("rewrite preference 1", async () => {
     const slugHelper = new SlugHelper(config);
     expect(slugHelper.rewrite("localhost", "xx")).toBe("rewritten_localhost");
     expect(slugHelper.rewrite("lighthouse", "xx")).toBe("rewritten_lighthouse");
   });
 
-  it("rewrite preference 2", async() => {
+  it("rewrite preference 2", async () => {
     const slugHelper = new SlugHelper(config);
     expect(slugHelper.rewrite(null, "lighthouse")).toBe("rewritten_lighthouse");
     expect(slugHelper.rewrite(undefined, "xx")).toBe("xx");
     expect(slugHelper.rewrite("", "xx")).toBe("xx");
   });
 
-  it("rewrite empty", async() => {
+  it("rewrite empty", async () => {
     const slugHelper = new SlugHelper(config);
     expect(slugHelper.rewrite(null)).toBe(null);
     expect(slugHelper.rewrite(undefined)).toBe(null);

--- a/oauth-proxy/tests/slug_helper.test.js
+++ b/oauth-proxy/tests/slug_helper.test.js
@@ -31,4 +31,24 @@ describe("slug helper tests", () => {
     const slugHelper = new SlugHelper({});
     expect(slugHelper.rewrite("xxx")).toBe("xxx");
   });
+
+  it("rewrite preference 1", async() => {
+    const slugHelper = new SlugHelper(config);
+    expect(slugHelper.rewrite("localhost", "xx")).toBe("rewritten_localhost");
+    expect(slugHelper.rewrite("lighthouse", "xx")).toBe("rewritten_lighthouse");
+  });
+
+  it("rewrite preference 2", async() => {
+    const slugHelper = new SlugHelper(config);
+    expect(slugHelper.rewrite(null, "lighthouse")).toBe("rewritten_lighthouse");
+    expect(slugHelper.rewrite(undefined, "xx")).toBe("xx");
+    expect(slugHelper.rewrite("", "xx")).toBe("xx");
+  });
+
+  it("rewrite empty", async() => {
+    const slugHelper = new SlugHelper(config);
+    expect(slugHelper.rewrite(null)).toBe(null);
+    expect(slugHelper.rewrite(undefined)).toBe(null);
+    expect(slugHelper.rewrite("")).toBe(null);
+  });
 });


### PR DESCRIPTION
https://vajira.max.gov/browse/API-6036

Allow the global default IDP to be overridden per authz route.

The IDP will be selected as the first non-empty IDP defined in this order
1. query param
2. authz route
3. global config

Additionally, all these locations now accept a slug, which will be resolved if present in the config.

Config PRs:
* https://github.com/department-of-veterans-affairs/devops/pull/8834
* https://github.com/department-of-veterans-affairs/lighthouse-oauth-proxy-configs/pull/30