### PR TITLE
remove health-insurance/v1 route

### DIFF
--- a/oauth-proxy/dev-config.base.json
+++ b/oauth-proxy/dev-config.base.json
@@ -47,11 +47,6 @@
         "enable_consent_endpoint" : true
       },
       {
-        "api_category": "/health-insurance/v1",
-        "upstream_issuer": "https://deptva-eval.okta.com/oauth2/aus8nm1q0f7VQ0a482p7",
-        "audience": "https://sandbox-api.va.gov/services/fhir"
-      },
-      {
         "api_category": "/health/system/v1",
         "upstream_issuer": "https://deptva-eval.okta.com/oauth2/aus8nm1q0f7VQ0a482p7",
         "audience": "https://sandbox-api.va.gov/services/fhir"


### PR DESCRIPTION
Remove deprecated health-insurance/v1 route
Related story: https://vajira.max.gov/browse/API-5872

Tests:
Unit tests pass.
Regression test script pass locally.

Related PRs: 
https://github.com/department-of-veterans-affairs/lighthouse-oauth-proxy-configs/pull/31
https://github.com/department-of-veterans-affairs/devops/pull/8912