### PR TITLE
Removing event-stream dependency.

### DIFF
--- a/saml-proxy/package-lock.json
+++ b/saml-proxy/package-lock.json
@@ -3773,11 +3773,6 @@
         "is-obj": "^2.0.0"
       }
     },
-    "duplexer": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
-    },
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -4484,20 +4479,6 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
-    "event-stream": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
-      "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
-      "requires": {
-        "duplexer": "^0.1.1",
-        "from": "^0.1.7",
-        "map-stream": "0.0.7",
-        "pause-stream": "^0.0.11",
-        "split": "^1.0.1",
-        "stream-combiner": "^0.2.2",
-        "through": "^2.3.8"
-      }
-    },
     "events": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
@@ -5055,11 +5036,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-    },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -8110,11 +8086,6 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
-    "map-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
-    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -9098,22 +9069,22 @@
           "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
         },
         "xml-crypto": {
-          "version": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.0.tgz",
+          "version": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.1.tgz",
           "from": "xml-crypto@>=2.0.0",
           "requires": {
             "xmldom": "0.5.0",
-            "xpath": "0.0.27"
+            "xpath": "0.0.32"
           },
           "dependencies": {
             "xmldom": {
-              "version": "0.1.27",
-              "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-              "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+              "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
             },
             "xpath": {
-              "version": "0.0.27",
-              "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
-              "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ=="
+              "version": "0.0.32",
+              "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
+              "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="
             }
           }
         },
@@ -9213,14 +9184,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
-    },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "requires": {
-        "through": "~2.3"
-      }
     },
     "pbkdf2": {
       "version": "3.1.1",
@@ -10148,12 +10111,12 @@
       },
       "dependencies": {
         "xml-crypto": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.0.tgz",
-          "integrity": "sha512-vDYaNYe5nq5ofb+rqdlIuSjojIDhifBOX8bfUcjJK3pB50qz3Uz50voKklaARvEjkGdbIMnNpt39Glrjx4ieuw==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.1.tgz",
+          "integrity": "sha512-M+m4+HIJa83lu/CnspQjA7ap8gmanNDxxRjSisU8mPD4bqhxbo5N2bdpvG2WgVYOrPpOIOq55iY8Cz8Ai40IeQ==",
           "requires": {
             "xmldom": "0.5.0",
-            "xpath": "0.0.27"
+            "xpath": "0.0.32"
           },
           "dependencies": {
             "xmldom": {
@@ -10162,9 +10125,9 @@
               "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
             },
             "xpath": {
-              "version": "0.0.27",
-              "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
-              "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ=="
+              "version": "0.0.32",
+              "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
+              "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="
             }
           }
         },
@@ -10193,18 +10156,18 @@
       },
       "dependencies": {
         "xml-crypto": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.0.tgz",
-          "integrity": "sha512-vDYaNYe5nq5ofb+rqdlIuSjojIDhifBOX8bfUcjJK3pB50qz3Uz50voKklaARvEjkGdbIMnNpt39Glrjx4ieuw==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.1.tgz",
+          "integrity": "sha512-M+m4+HIJa83lu/CnspQjA7ap8gmanNDxxRjSisU8mPD4bqhxbo5N2bdpvG2WgVYOrPpOIOq55iY8Cz8Ai40IeQ==",
           "requires": {
             "xmldom": "0.5.0",
-            "xpath": "0.0.27"
+            "xpath": "0.0.32"
           },
           "dependencies": {
             "xpath": {
-              "version": "0.0.27",
-              "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
-              "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ=="
+              "version": "0.0.32",
+              "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
+              "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="
             }
           }
         },
@@ -10917,14 +10880,6 @@
       "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
       "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg=="
     },
-    "split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "requires": {
-        "through": "2"
-      }
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -11025,15 +10980,6 @@
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
-      }
-    },
-    "stream-combiner": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-      "requires": {
-        "duplexer": "~0.1.1",
-        "through": "~2.3.4"
       }
     },
     "stream-combiner2": {

--- a/saml-proxy/package.json
+++ b/saml-proxy/package.json
@@ -83,7 +83,6 @@
     "cookie-parser": "^1.4.5",
     "debug": "~3.1.0",
     "eslint-plugin-jest": "^23.20.0",
-    "event-stream": "^3.3.5",
     "express": "^4.17.1",
     "express-prom-bundle": "^5.1.5",
     "express-session": "^1.17.1",


### PR DESCRIPTION
https://vajira.max.gov/browse/API-5684

Decided to remove the even-stream dependency, as it was not being used by anything.