### PR TITLE
Api 5677 saml prometheus major upgrade

### DIFF
--- a/saml-proxy/package-lock.json
+++ b/saml-proxy/package-lock.json
@@ -9749,9 +9749,9 @@
       "dev": true
     },
     "prom-client": {
-      "version": "11.5.3",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.3.tgz",
-      "integrity": "sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.1.0.tgz",
+      "integrity": "sha512-jT9VccZCWrJWXdyEtQddCDszYsiuWj5T0ekrPszi/WEegj3IZy6Mm09iOOVM86A4IKMWq8hZkT2dD9MaSe+sng==",
       "requires": {
         "tdigest": "^0.1.1"
       }

--- a/saml-proxy/package-lock.json
+++ b/saml-proxy/package-lock.json
@@ -4789,9 +4789,9 @@
       }
     },
     "express-prom-bundle": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/express-prom-bundle/-/express-prom-bundle-5.1.5.tgz",
-      "integrity": "sha512-tUaQUBu0r9zGYcVDpKBI2AeWimuuodaC5BSBkzLPQxRTxaKQShQNnONQSYwjLxbHfPwlCKVZlzfbB9Recnj0Vg==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/express-prom-bundle/-/express-prom-bundle-6.3.6.tgz",
+      "integrity": "sha512-IRsTRCEKCVCHEriQlZ1FuutjEFc89KASsveXh+1HcGEnuZKiAC4LugxrsGEIdySqYvqOYSr2SWHJ6L8/BK2SHA==",
       "requires": {
         "on-finished": "^2.3.0",
         "url-value-parser": "^2.0.0"
@@ -12627,9 +12627,9 @@
       }
     },
     "url-value-parser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/url-value-parser/-/url-value-parser-2.0.1.tgz",
-      "integrity": "sha512-bexECeREBIueboLGM3Y1WaAzQkIn+Tca/Xjmjmfd0S/hFHSCEoFkNh0/D0l9G4K74MkEP/lLFRlYnxX3d68Qgw=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/url-value-parser/-/url-value-parser-2.0.3.tgz",
+      "integrity": "sha512-FjIX+Q9lYmDM9uYIGdMYfQW0uLbWVwN2NrL2ayAI7BTOvEwzH+VoDdNquwB9h4dFAx+u6mb0ONLa3sHD5DvyvA=="
     },
     "use": {
       "version": "3.1.1",

--- a/saml-proxy/package.json
+++ b/saml-proxy/package.json
@@ -84,7 +84,7 @@
     "debug": "~3.1.0",
     "eslint-plugin-jest": "^23.20.0",
     "express": "^4.17.1",
-    "express-prom-bundle": "^5.1.5",
+    "express-prom-bundle": "^6.3.6",
     "express-session": "^1.17.1",
     "extend": "^3.0.2",
     "font-awesome": "^4.7.0",

--- a/saml-proxy/package.json
+++ b/saml-proxy/package.json
@@ -99,7 +99,7 @@
     "node-sass-tilde-importer": "^1.0.2",
     "passport": "^0.4.1",
     "passport-wsfed-saml2": "git+https://github.com/department-of-veterans-affairs/lighthouse-passport-wsfed-saml2.git",
-    "prom-client": "^11.5.3",
+    "prom-client": "^13.1.0",
     "redis": "^3.0.2",
     "request": "^2.88.2",
     "request-promise-native": "^1.0.9",

--- a/saml-proxy/src/metrics.ts
+++ b/saml-proxy/src/metrics.ts
@@ -57,7 +57,7 @@ export const VSORequestMetrics = {
 };
 
 export interface IRequestMetrics {
-  histogram: client.Histogram;
-  attempt: client.Counter;
-  failure: client.Counter;
+  histogram: client.Histogram<any>;
+  attempt: client.Counter<any>;
+  failure: client.Counter<any>;
 }


### PR DESCRIPTION
related story: https://vajira.max.gov/browse/API-5677
unit tests pass, regression tests pass, dependencies no longer present in `npm outdated`