### PR TITLE
upgrade debug dependency to 4.3.1

### DIFF
--- a/saml-proxy/package-lock.json
+++ b/saml-proxy/package-lock.json
@@ -3582,18 +3582,11 @@
       }
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "requires": {
-        "ms": "2.0.0"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
+        "ms": "2.1.2"
       }
     },
     "decamelize": {

--- a/saml-proxy/package.json
+++ b/saml-proxy/package.json
@@ -81,7 +81,7 @@
     "cls-rtracer": "^2.6.0",
     "connect-flash": "^0.1.1",
     "cookie-parser": "^1.4.5",
-    "debug": "~3.1.0",
+    "debug": "~4.3.1",
     "eslint-plugin-jest": "^23.20.0",
     "express": "^4.17.1",
     "express-prom-bundle": "^6.3.6",


### PR DESCRIPTION
upgrade debug dependency from 3.1.0 to 4.3.1.
unit and regression tests pass, debug no longer present in `npm outdated`