### PR TITLE
API-6709 - Enforce linting

### DIFF
--- a/oauth-proxy/DockerfileFG
+++ b/oauth-proxy/DockerfileFG
@@ -29,6 +29,8 @@ COPY --chown=node:node ./oauth-proxy/package.json package.json
 COPY --chown=node:node ./oauth-proxy/package-lock.json package-lock.json
 RUN npm install
 
+RUN npm run-script lint
+
 USER root
 RUN mkdir -p /home/common && \
   chown -R node:node /home/common


### PR DESCRIPTION
https://vajira.max.gov/browse/API-6709

Enforce linting on CI builds by including it in the Fargate Dockerfile. Build will fail if linting fails.