### PR TITLE
API-5707 switch to use auth0/passport-wsfed-saml2

### DIFF
--- a/saml-proxy/package-lock.json
+++ b/saml-proxy/package-lock.json
@@ -2555,14 +2555,6 @@
         }
       }
     },
-    "boom": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
-      "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
-      "requires": {
-        "hoek": "6.x.x"
-      }
-    },
     "boxen": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
@@ -3572,14 +3564,6 @@
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         }
-      }
-    },
-    "cryptiles": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.3.tgz",
-      "integrity": "sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw==",
-      "requires": {
-        "boom": "7.x.x"
       }
     },
     "crypto-browserify": {
@@ -5652,11 +5636,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "hoek": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
-      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
     },
     "hosted-git-info": {
       "version": "2.8.9",
@@ -8761,6 +8740,11 @@
         "clone": "2.x"
       }
     },
+    "node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+    },
     "node-gyp": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
@@ -9326,48 +9310,28 @@
       "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
     },
     "passport-wsfed-saml2": {
-      "version": "git+https://github.com/department-of-veterans-affairs/lighthouse-passport-wsfed-saml2.git#90244214545b77532174891e557404f63cbd5778",
-      "from": "git+https://github.com/department-of-veterans-affairs/lighthouse-passport-wsfed-saml2.git",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/passport-wsfed-saml2/-/passport-wsfed-saml2-4.4.0.tgz",
+      "integrity": "sha512-rL2iI5/kVd7X1xZH87XMMP70JKgl9H53ImX6oGLawep0ElIkK6xUQuzRXPgPkIbfjrgfYGSi7MauW1INXdhE2w==",
       "requires": {
-        "cryptiles": "~4.1.3",
+        "@auth0/xmldom": "0.1.22",
         "ejs": "2.5.5",
         "jsonwebtoken": "~5.0.4",
         "node-forge": "^0.10.0",
         "passport-strategy": "^1.0.0",
         "uid2": "0.0.x",
         "valid-url": "^1.0.9",
-        "xml-crypto": "xml-crypto@>=2.0.0",
+        "xml-crypto": "github:auth0/xml-crypto#v1.4.1-auth0.2",
         "xml-encryption": "^1.2.1",
         "xml2js": "0.1.x",
-        "xmldom": "github:auth0/xmldom#v0.1.19-auth0.2",
         "xpath": "0.0.5",
         "xtend": "~2.0.3"
       },
       "dependencies": {
-        "node-forge": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
-        },
-        "xml-crypto": {
-          "version": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.2.tgz",
-          "from": "xml-crypto@>=2.0.0",
-          "requires": {
-            "xmldom": "^0.6.0",
-            "xpath": "0.0.32"
-          },
-          "dependencies": {
-            "xmldom": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-              "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
-            },
-            "xpath": {
-              "version": "0.0.32",
-              "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
-              "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="
-            }
-          }
+        "@auth0/xmldom": {
+          "version": "0.1.22",
+          "resolved": "https://registry.npmjs.org/@auth0/xmldom/-/xmldom-0.1.22.tgz",
+          "integrity": "sha512-5JwOXYW9Ex9IRGfjCQbcRBqWxST9nG7hXrHj3X64h0xA4CtEsbnBCbAUF9cKJEMreHmFVsRtK41IvJIuU21/ig=="
         },
         "xml2js": {
           "version": "0.1.14",
@@ -9376,10 +9340,6 @@
           "requires": {
             "sax": ">=0.1.1"
           }
-        },
-        "xmldom": {
-          "version": "github:auth0/xmldom#2795a7ed785ab8c2bf58231e3d6677ac57d3aee8",
-          "from": "github:auth0/xmldom#v0.1.19-auth0.2"
         }
       }
     },
@@ -13295,6 +13255,26 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
+    },
+    "xml-crypto": {
+      "version": "github:auth0/xml-crypto#dbd5d046903d245af5647804ba54ae7a1230af15",
+      "from": "github:auth0/xml-crypto#v1.4.1-auth0.2",
+      "requires": {
+        "xmldom": "0.1.27",
+        "xpath": "0.0.27"
+      },
+      "dependencies": {
+        "xmldom": {
+          "version": "0.1.27",
+          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+          "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+        },
+        "xpath": {
+          "version": "0.0.27",
+          "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
+          "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ=="
+        }
+      }
     },
     "xml-encryption": {
       "version": "1.2.3",

--- a/saml-proxy/package.json
+++ b/saml-proxy/package.json
@@ -36,7 +36,7 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "lines": 80.62
+        "lines": 80.88
       }
     },
     "transform": {

--- a/saml-proxy/package.json
+++ b/saml-proxy/package.json
@@ -36,7 +36,7 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "lines": 80.62
+        "lines": 80.59
       }
     },
     "transform": {

--- a/saml-proxy/package.json
+++ b/saml-proxy/package.json
@@ -36,7 +36,7 @@
     "collectCoverage": true,
     "coverageThreshold": {
       "global": {
-        "lines": 80.59
+        "lines": 80.62
       }
     },
     "transform": {

--- a/saml-proxy/package.json
+++ b/saml-proxy/package.json
@@ -96,7 +96,7 @@
     "node-sass-middleware": "^0.11.0",
     "node-sass-tilde-importer": "^1.0.2",
     "passport": "^0.4.1",
-    "passport-wsfed-saml2": "git+https://github.com/department-of-veterans-affairs/lighthouse-passport-wsfed-saml2.git",
+    "passport-wsfed-saml2": "^4.4.0",
     "prom-client": "^13.1.0",
     "redis": "^3.0.2",
     "request": "^2.88.2",

--- a/saml-proxy/test/testServer.js
+++ b/saml-proxy/test/testServer.js
@@ -5,7 +5,6 @@ import IDPConfig from "../src/IDPConfig";
 import configureExpress from "../src/routes";
 import { TestCache } from "../src/routes/types";
 import SPConfig from "../src/SPConfig";
-import { removeHeaders } from "../src/utils";
 
 import { idpCert, idpKey, spCert, spKey } from "./testCerts";
 
@@ -23,7 +22,7 @@ const defaultTestingConfig = {
   spIdpIssuer: "api.idmelabs.com",
   spAuthnContextClassRef: "http://idmanagement.gov/ns/assurance/loa/3",
   spAcsUrls: ["/samlproxy/sp/saml/sso"],
-  idpCert: removeHeaders(idpCert),
+  idpCert: idpCert,
   idpKey: Buffer.from(idpKey, "utf-8"),
   spCert: Buffer.from(spCert, "utf-8"),
   spKey: Buffer.from(spKey, "utf-8"),

--- a/saml-proxy/test/utils.test.js
+++ b/saml-proxy/test/utils.test.js
@@ -1,0 +1,39 @@
+require("jest");
+
+import { getReqUrl, removeHeaders } from "../src/utils";
+import { idpCert } from "./testCerts";
+
+describe("Tests for utils.js", () => {
+  test("Test for removeHeaders", () => {
+    let cert = removeHeaders(idpCert);
+    const expectedCert =
+      "MIIDuzCCAqOgAwIBAgIUHOMabPdUAltQPOSGkmXa7wVGEZQwDQYJKoZIhvcNAQELBQAwbTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lzY28xEDAOBgNVBAoMB0phbmt5Q28xHzAdBgNVBAMMFlRlc3QgSWRlbnRpdHkgUHJvdmlkZXIwHhcNMjAwMTA3MTY0ODEyWhcNNDAwMTAyMTY0ODEyWjBtMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzEQMA4GA1UECgwHSmFua3lDbzEfMB0GA1UEAwwWVGVzdCBJZGVudGl0eSBQcm92aWRlcjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMrac33GLykOs6ThReh3op/LwrNx+8CsUJXFfn4t0NYAcq2ZgR5qFz00Sn5IO/OO2qteITyFkBFICX8PVyJxlXrf8eQ4qJ6OKaN4g2sWqs2wU9W/Y5DE4yuU22Uuw6NRVM0cs7D8+/qAz3dC7SOi7wlEojHm0na/LSypYi0WQH2Phb1Eh73j4Tdi60wURgnMF4RbUynUxJCuG4MBmOGCy0kW2n/ZEixGiHMYO6qfcR5XtXSuSejHvSPLS39N40Fl0Z88rIfe664ycd2Ih8SB3qP74d1gCADknUCyydhZuggr5DJG0/3N4jaGgYBsLmUq1T7yZDqY9F/mq22jn7TQWUUCAwEAAaNTMFEwHQYDVR0OBBYEFE8LUpzxF/SDx7w6V62o/HPaNnvMMB8GA1UdIwQYMBaAFE8LUpzxF/SDx7w6V62o/HPaNnvMMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAEUMISb1wLsowsrAsSWbQvUEn4sAGWF4QJl8SSzLudW57P868/NgHXZ10H2Hcc1nCFSZx7Oq620T8yi9QEEn0c4CoAIiituokpWSsAL2/WwD2MTX8SoUvYo2JJFGWvGAbI4o3APnJ0X+r6g6Vsm2i5L0PVNJ1aUid/hLoat1ITLpGqQCbhdan3B6D+6PE4IbNBHCimcTREuBYtk2NOcUC0ftBFrv8pOf1WEI+GoPuS1peIM0oQmduoqTM0o3H/OgzesQNDmLrHdY2+1AxhBhySUWi9c0Wt+LjX0t3Rh67byTEd83OSJB+qXGcR4W96+psF+UlJRViui5vY1Y+JPCRDM=";
+    expect(cert).toBe(expectedCert);
+    cert = removeHeaders(cert);
+    expect(cert).toBe(expectedCert);
+  });
+
+  test("Test for getReqUrl", () => {
+    let req = {
+      get: function (prop) {
+        switch (prop) {
+          case "host":
+            return this.host;
+          case "x-forwarded-host":
+            return this.x_fowarded_host;
+          default:
+            return "unexpected";
+        }
+      },
+      host: "example.com",
+      originalUrl: "http://original.example.com",
+      x_fowarded_host: "fowarded.example.com",
+    };
+    let result = getReqUrl(req, "test/path/1");
+    expect(result).toBe("https://fowarded.example.com/test/path/1");
+    req.host = "localhost:7000";
+    req.x_fowarded_host = undefined;
+    result = getReqUrl(req, "test/path/1");
+    expect(result).toBe("http://localhost:7000/test/path/1");
+  });
+});

--- a/saml-proxy/tsconfig.json
+++ b/saml-proxy/tsconfig.json
@@ -11,7 +11,7 @@
   },
   "include": [
     "./src/**/*"
-  ],
+, "test/utils.test.js"  ],
   "exclude": [
     "node_modules",
     "./src/**/*.test.ts"


### PR DESCRIPTION
Update to use original upstream project at https://github.com/auth0/passport-wsfed-saml2 instead of a fork at https://github.com/department-of-veterans-affairs/lighthouse-passport-wsfed-saml2