### PR TITLE
Add request ids to IDP saml requests

### DIFF
--- a/oauth-proxy/package-lock.json
+++ b/oauth-proxy/package-lock.json
@@ -14553,9 +14553,9 @@
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "jose": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.5.tgz",
-      "integrity": "sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.4.tgz",
+      "integrity": "sha512-EArN9f6aq1LT/fIGGsfghOnNXn4noD+3dG5lL/ljY3LcRjw1u9w+4ahu/4ahsN6N0kRLyyW6zqdoYk7LNx3+YQ==",
       "requires": {
         "@panva/asn1.js": "^1.0.0"
       }

--- a/saml-proxy/src/SPConfig.js
+++ b/saml-proxy/src/SPConfig.js
@@ -69,7 +69,7 @@ export default class SPConfig {
     };
   }
 
-  getAuthnRequestParams(acsUrl, forceAuthn, relayState, authnContext) {
+  getAuthnRequestParams(acsUrl, forceAuthn, relayState, authnContext, id) {
     const params = {
       protocol: this.protocol,
       realm: this.audience,
@@ -80,6 +80,7 @@ export default class SPConfig {
       forceAuthn: forceAuthn,
       authnContext: authnContext || this.authnContextClassRef,
       requestContext: {
+        ID: id,
         NameIDFormat: this.nameIDFormat,
       },
       requestTemplate: AUTHN_REQUEST_TEMPLATE({

--- a/saml-proxy/src/routes/handlers.js
+++ b/saml-proxy/src/routes/handlers.js
@@ -74,7 +74,8 @@ export const samlLogin = function (template) {
           acsUrl,
           (authnRequest && authnRequest.forceAuthn) || "false",
           relayState || "/",
-          authnContext
+          authnContext,
+          rTracer.id()
         );
         return memo.then((m) => {
           return new Promise((resolve, reject) => {

--- a/saml-proxy/test/e2e.test.js
+++ b/saml-proxy/test/e2e.test.js
@@ -10,7 +10,7 @@ import { MHV_USER, DSLOGON_USER, IDME_USER, getUser } from "./testUsers";
 import MockVetsApiClient from "./mockVetsApiClient";
 import atob from "atob";
 import btoa from "btoa";
-
+import zlib from "zlib";
 const {
   startServerInBackground,
   stopBackgroundServer,
@@ -62,6 +62,20 @@ function ssoRequest(samlResponse, state = "state") {
   return request(reqOpts);
 }
 
+async function ssoIdpRequest() {
+  const reqOpts = {
+    method: "POST",
+    resolveWithFullResponse: true,
+    uri: `http://localhost:${PORT}/samlproxy/idp/saml/sso`,
+    form: {
+      SAMLRequest:
+        "PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48c2FtbDJwOkF1dGhuUmVxdWVzdCBBc3NlcnRpb25Db25zdW1lclNlcnZpY2VVUkw9Imh0dHBzOi8vZGVwdHZhLWV2YWwub2t0YS5jb20vc3NvL3NhbWwyLzBvYTM3eDJjd2Y5eU90cUdiMnA3IiBEZXN0aW5hdGlvbj0iaHR0cDovL2xvY2FsaG9zdDo3MDAwL3NzbyIgRm9yY2VBdXRobj0iZmFsc2UiIElEPSJpZDE4MjMzNTA2MjM0MTUxMDQxMjAwMjE5OTMwNCIgSXNzdWVJbnN0YW50PSIyMDIxLTAyLTA5VDE5OjA4OjE2LjMzNFoiIFZlcnNpb249IjIuMCIgeG1sbnM6c2FtbDJwPSJ1cm46b2FzaXM6bmFtZXM6dGM6U0FNTDoyLjA6cHJvdG9jb2wiPjxzYW1sMjpJc3N1ZXIgeG1sbnM6c2FtbDI9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDphc3NlcnRpb24iPmh0dHBzOi8vd3d3Lm9rdGEuY29tL3NhbWwyL3NlcnZpY2UtcHJvdmlkZXIvc3BheXF6dHB4eWZqa2V1bnhvYnc8L3NhbWwyOklzc3Vlcj48ZHM6U2lnbmF0dXJlIHhtbG5zOmRzPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjIj48ZHM6U2lnbmVkSW5mbz48ZHM6Q2Fub25pY2FsaXphdGlvbk1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMTAveG1sLWV4Yy1jMTRuIyIvPjxkczpTaWduYXR1cmVNZXRob2QgQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNyc2Etc2hhMjU2Ii8+PGRzOlJlZmVyZW5jZSBVUkk9IiNpZDE4MjMzNTA2MjM0MTUxMDQxMjAwMjE5OTMwNCI+PGRzOlRyYW5zZm9ybXM+PGRzOlRyYW5zZm9ybSBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvMDkveG1sZHNpZyNlbnZlbG9wZWQtc2lnbmF0dXJlIi8+PGRzOlRyYW5zZm9ybSBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMTAveG1sLWV4Yy1jMTRuIyIvPjwvZHM6VHJhbnNmb3Jtcz48ZHM6RGlnZXN0TWV0aG9kIEFsZ29yaXRobT0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnI3NoYTEiLz48ZHM6RGlnZXN0VmFsdWU+RER2UVB5UkxLdFZCSkV4VzZCc2tsTTJjYStvPTwvZHM6RGlnZXN0VmFsdWU+PC9kczpSZWZlcmVuY2U+PC9kczpTaWduZWRJbmZvPjxkczpTaWduYXR1cmVWYWx1ZT5EbUpKclVKenZWNDBUYkJ0VzJHOWN6Z1F5T1BmTVcxYlpWN0czTHpRTmNHeDIyVy9lRnpkVjJocFo5eC9hSkRKRjM4S3Y2UnVOT3NtUWprTDVLQlNBSm1aZVlPNTEzcDJFcGFzWnQwRkhXRUlFWlFOcU9KTmh6OXdDRDBUbjRnMGhPSUVNaHRCVVU2aDd5ZlJlenRkamtteWYrUzEyWVY5UytIM3J3eXlFR2lSQWhQNWpsd2ZUNkpBS3liOUgzUk5QZ0Z0MWU2MWM5MXNDc01qRlhORy9TRWdZOEVENmplbTRibUE1Y0VjeDlYRlNLZEt0MjJxVkJZRlNJTzZ5SGE5M3BmTlZ3K2ZEdTZnbkQvS2lFT21HeGxQK2lrZjVBVnhHd3gvY1BuTFBBYStwaFloYnViazNjU0dLbU9Zb0ZYeU50MlVMTmZKWUZwZU1xVVlzTnNON3c9PTwvZHM6U2lnbmF0dXJlVmFsdWU+PGRzOktleUluZm8+PGRzOlg1MDlEYXRhPjxkczpYNTA5Q2VydGlmaWNhdGU+TUlJRHRqQ0NBcDZnQXdJQkFnSUdBV1BaK3IvSE1BMEdDU3FHU0liM0RRRUJDd1VBTUlHYk1Rc3dDUVlEVlFRR0V3SlZVekVUTUJFRwpBMVVFQ0F3S1EyRnNhV1p2Y201cFlURVdNQlFHQTFVRUJ3d05VMkZ1SUVaeVlXNWphWE5qYnpFTk1Bc0dBMVVFQ2d3RVQydDBZVEVVCk1CSUdBMVVFQ3d3TFUxTlBVSEp2ZG1sa1pYSXhIREFhQmdOVkJBTU1FMlJsY0hSMllTMTJaWFJ6WjI5MkxXVjJZV3d4SERBYUJna3EKaGtpRzl3MEJDUUVXRFdsdVptOUFiMnQwWVM1amIyMHdIaGNOTVRnd05qQTNNVEV5TURFNVdoY05Namd3TmpBM01URXlNVEU0V2pDQgptekVMTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnTUNrTmhiR2xtYjNKdWFXRXhGakFVQmdOVkJBY01EVk5oYmlCR2NtRnVZMmx6ClkyOHhEVEFMQmdOVkJBb01CRTlyZEdFeEZEQVNCZ05WQkFzTUMxTlRUMUJ5YjNacFpHVnlNUnd3R2dZRFZRUUREQk5rWlhCMGRtRXQKZG1WMGMyZHZkaTFsZG1Gc01Sd3dHZ1lKS29aSWh2Y05BUWtCRmcxcGJtWnZRRzlyZEdFdVkyOXRNSUlCSWpBTkJna3Foa2lHOXcwQgpBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUFsYm52czYwN2thOEN2ekRFS0RIUFJWN1hvd2o4SkUveVN2RmtKRENGaWZjZ28wMlIvTEE3CkM5RHVLN20vS0l2dU9WakRWZ0JaVUlWeHNGeFQvRnBsc2ZEcDJDK3FJbVFmKzRvb0p1dTZhci9xTW9JZmRUbEN1TjRjV2F4L0cxWGQKMFFNOFpqSjVEbVJWcW1aNk91NTFld29jYWlrS20yS2E2dmhQTUdPVGdUa3V2YnJBRXRTczdMcFRoWjJydHRsb044ZkJsSk1yOFFidAp0YjNFaEV1cWtVRExjNEJkTVYxenRzcFlTbDhIZ1NlLy9tS2JVazNkcldMRFhZZU02YXdRWk9NTzFJVzJpTnpHQk5UcjBqWDBPVXNoCjRjczgvRXpHaFFsbGlYU0hmZHNrTEpGSjMycjVmM1BmdTc5Sks3ZGdUd3c1SkZWeG9OWjJkZUEwenhnU2FRSURBUUFCTUEwR0NTcUcKU0liM0RRRUJDd1VBQTRJQkFRQVpJL1dpSUpON2FScXRWaXd6S2ZXTHYvbWF0dzMrdXFFWjdBU0dDZXZPV2tEdnhFMk9qME5RZllHbgpRZllOYkszR1I5bWtUdjVyOTE1aE41SmJKTERFVTZLcVZzdzlFRW5GZ1RTd1NOd014NnY5Q3craEdFS3dTbURzbnoxaXgzUjJ6Q2lWCmZtd3NzeUpiRlRiQk9PeW5NZE43RTVpWnBwZ21IejBuZThkbE15NEh0bm05WnNCN001ejJyaU9QUUxCUzVXSHFPeVlyTDNHOHhNT0wKVkMvK2hycWNDRVRsUDZtei9iWjhsa28xZFFpcm9NU1ROQ0U5UEtpQ3V2bk9IZWxndm9NMmR4RmE1SUc5eVBlNlA4NGFHS0FBb0hjbQpkS2NOY0NjRnluOXJpRW14WWZVbnZLdllzbGw2MGY0dkZIblJ3L1RzbGIwcXZqVXBZQlNBUWhhSjwvZHM6WDUwOUNlcnRpZmljYXRlPjwvZHM6WDUwOURhdGE+PC9kczpLZXlJbmZvPjwvZHM6U2lnbmF0dXJlPjxzYW1sMnA6TmFtZUlEUG9saWN5IEZvcm1hdD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6MS4xOm5hbWVpZC1mb3JtYXQ6dW5zcGVjaWZpZWQiLz48L3NhbWwycDpBdXRoblJlcXVlc3Q+",
+      RelayState: "state",
+    },
+  };
+
+  return request(reqOpts);
+}
 // These are the HTML parsers. The SSO endpoint renders HTML/javascript that automatically
 // submits a form of the SAMLResponse and RelayState back to Okta. It doesn't simply redirect
 // because it would need to do a 307 redirect to stay a POST. The user would need to "approve"
@@ -164,6 +178,27 @@ function responseResultType(response) {
   return UNKNOWN;
 }
 
+function decode_saml_uri(saml) {
+  var uriDecoded = decodeURIComponent(saml);
+  var b64decoded = new Buffer.from(uriDecoded, "base64");
+  return zlib.inflateRawSync(b64decoded).toString();
+}
+
+function getIdpSamlRequest(response, class_tags) {
+  const parser = new DOMParser();
+  const parsed = parser.parseFromString(response.body, MIME_HTML);
+  const url = parsed
+    .getElementsByClassName(class_tags)
+    ["0"].getAttributeNode("href").nodeValue;
+  return decode_saml_uri(new URL(url).searchParams.get("SAMLRequest"));
+}
+
+function getIdFromSamlRequest(request) {
+  const parser = new DOMParser();
+  const parsed = parser.parseFromString(request);
+  return parsed.documentElement.getAttributeNode("ID").nodeValue;
+}
+
 describe("Logins for idp", () => {
   beforeAll(() => {
     const app = getTestExpressApp(vetsApiClient);
@@ -176,6 +211,31 @@ describe("Logins for idp", () => {
 
   beforeEach(() => {
     vetsApiClient.reset();
+  });
+
+  it("Saml Request check for Request IDs", async () => {
+    let response = await ssoIdpRequest();
+    let dsLogonRequest = getIdpSamlRequest(
+      response,
+      "no-external-icon usa-button dslogon"
+    );
+    let dsLogonId = getIdFromSamlRequest(dsLogonRequest);
+    expect(dsLogonId).toBeTruthy;
+    let myHealtheVetRequest = getIdpSamlRequest(
+      response,
+      "no-external-icon usa-button mhv"
+    );
+    let myHealtheVetID = getIdFromSamlRequest(myHealtheVetRequest);
+    expect(myHealtheVetID).toBeTruthy;
+    let idMeRequest = getIdpSamlRequest(
+      response,
+      "no-external-icon usa-button idme-signin"
+    );
+    let idMeID = getIdFromSamlRequest(idMeRequest);
+    expect(idMeID).toBeTruthy;
+    expect(dsLogonId).toEqual(myHealtheVetID);
+    expect(dsLogonId).toEqual(idMeID);
+    expect(dsLogonId).not.toEqual("@@ID@@");
   });
 
   it("uses the RelayState from the request", async () => {


### PR DESCRIPTION
For the purposes of trouble shooting, saml requests to IDPs should have unique RequestIDs

# Things to know

I made the request IDs match the express request ID. I think it would be helpful to be able to connect the messages to their express request.

# AC

- [x] Add e2e test
- [x] Verify requests IDs have been added to the saml requests
![image](https://user-images.githubusercontent.com/65039481/117878746-4e4b5b80-b263-11eb-922a-f5221fa2fb55.png)
