### PR TITLE
Dockerize Regression ests

### DIFF
--- a/oauth-proxy/Dockerfile.bats
+++ b/oauth-proxy/Dockerfile.bats
@@ -1,0 +1,15 @@
+FROM docker:latest
+
+COPY /tests/bats /bats
+COPY /entrypoint_test.sh /bats/entrypoint_test.sh
+
+RUN apk update
+
+RUN apk add jq \
+    bash \
+    curl \
+    bats
+  
+WORKDIR /bats
+
+ENTRYPOINT [ "./entrypoint_test.sh" ]

--- a/oauth-proxy/entrypoint_test.sh
+++ b/oauth-proxy/entrypoint_test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Team Pivot!
+
+usage() {
+cat <<EOF
+Runs oauth proxy's regression tests.
+
+docker run --rm vasdvp/lighthouse-oauth-proxy-tests \
+  --user-email="$USER_EMAIL" \
+  --user-password="$USER_PASSWORD" \
+  --client-id="$CLIENT_ID" \
+  --client-secret="$CLIENT_SECRET" \
+  --cc-client-id="$CC_CLIENT_ID" \
+  --cc-client-secret="$CC_CLIENT_SECRET" \
+  --host="$HOST" \
+  --test-claims
+EOF
+}
+
+if [ $# -eq 0 ]; then
+  usage
+  exit 1
+fi

--- a/oauth-proxy/entrypoint_test.sh
+++ b/oauth-proxy/entrypoint_test.sh
@@ -6,13 +6,13 @@ cat <<EOF
 Runs oauth proxy's regression tests.
 
 docker run --rm vasdvp/lighthouse-oauth-proxy-tests \
-  --user-email="$USER_EMAIL" \
-  --user-password="$USER_PASSWORD" \
-  --client-id="$CLIENT_ID" \
-  --client-secret="$CLIENT_SECRET" \
-  --cc-client-id="$CC_CLIENT_ID" \
-  --cc-client-secret="$CC_CLIENT_SECRET" \
-  --host="$HOST" \
+  --user-email="\$USER_EMAIL" \
+  --user-password="\$USER_PASSWORD" \
+  --client-id="\$CLIENT_ID" \
+  --client-secret="\$CLIENT_SECRET" \
+  --cc-client-id="\$CC_CLIENT_ID" \
+  --cc-client-secret="\$CC_CLIENT_SECRET" \
+  --host="\$HOST" \
   --test-claims
 EOF
 }
@@ -55,4 +55,4 @@ case $i in
 esac
 done
 
-./bats/regression_tests.sh $TEST_CLAIMS
+./regression_tests.sh $TEST_CLAIMS

--- a/oauth-proxy/entrypoint_test.sh
+++ b/oauth-proxy/entrypoint_test.sh
@@ -21,3 +21,38 @@ if [ $# -eq 0 ]; then
   usage
   exit 1
 fi
+
+USER_EMAIL=
+USER_PASSWORD=
+CLIENT_ID=
+CLIENT_SECRET=
+CC_CLIENT_ID=
+CC_CLIENT_SECRET=
+HOST=
+TEST_CLAIMS=
+
+for i in "$@"
+do
+case $i in
+    --help|-h)
+      usage; exit 1 ;;
+    --test-claims)
+      TEST_CLAIMS="--test-claims"; shift ;;
+    --user-email=*)
+      export USER_EMAIL="${i#*=}"; shift ;;
+    --user-password=*)
+      export USER_PASSWORD="${i#*=}"; shift ;;
+    --client-id=*)
+      export CLIENT_ID="${i#*=}"; shift ;;
+    --client-secret*)
+      export CLIENT_SECRET="${i#*=}"; shift ;;
+    --cc-client-id*)
+      export CC_CLIENT_ID="${i#*=}"; shift ;;
+    --cc-client-secret*)
+      export CC_CLIENT_SECRET="${i#*=}"; shift ;;
+    --host*)
+      export HOST="${i#*=}"; shift ;;
+esac
+done
+
+./bats/regression_tests.sh $TEST_CLAIMS

--- a/oauth-proxy/entrypoint_test.sh
+++ b/oauth-proxy/entrypoint_test.sh
@@ -5,7 +5,9 @@ usage() {
 cat <<EOF
 Runs oauth proxy's regression tests.
 
-docker run --rm vasdvp/lighthouse-oauth-proxy-tests \
+docker run \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  --rm vasdvp/lighthouse-oauth-proxy-tests \
   --user-email="\$USER_EMAIL" \
   --user-password="\$USER_PASSWORD" \
   --client-id="\$CLIENT_ID" \


### PR DESCRIPTION
The 1st part of a 3 part effort to add the regression tests to the oauth-proxy CI. 

# To ensure functionality
- [ ] test pass against locally running oauth proxy
- [x] test pass agains sandbox oauth proxy